### PR TITLE
FISH-8344 Backport Fixes for CVE-2023-4043

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -23,14 +23,14 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>json</artifactId>
-        <version>1.1.6.payara-p1</version>
+        <version>1.1.6.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <groupId>jakarta.json</groupId>
     <artifactId>jakarta.json-api</artifactId>
     <packaging>bundle</packaging>
-    <version>1.1.6.payara-p1</version>
+    <version>1.1.6.payara-p2-SNAPSHOT</version>
     <name>Jakarta JSON Processing API</name>
     <description>Jakarta JSON Processing defines a Java(R) based framework for parsing, generating, transforming, and querying JSON documents.</description>
     <url>https://github.com/eclipse-ee4j/jsonp</url>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -23,14 +23,14 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>json</artifactId>
-        <version>1.1.6.payara-p1-SNAPSHOT</version>
+        <version>1.1.6.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <groupId>jakarta.json</groupId>
     <artifactId>jakarta.json-api</artifactId>
     <packaging>bundle</packaging>
-    <version>1.1.6.payara-p1-SNAPSHOT</version>
+    <version>1.1.6.payara-p1</version>
     <name>Jakarta JSON Processing API</name>
     <description>Jakarta JSON Processing defines a Java(R) based framework for parsing, generating, transforming, and querying JSON documents.</description>
     <url>https://github.com/eclipse-ee4j/jsonp</url>

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>json</artifactId>
-        <version>1.1.6.payara-p1-SNAPSHOT</version>
+        <version>1.1.6.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>json</artifactId>
-        <version>1.1.6.payara-p1</version>
+        <version>1.1.6.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/bundles/ri/pom.xml
+++ b/bundles/ri/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>json-bundles</artifactId>
-        <version>1.1.6.payara-p1</version>
+        <version>1.1.6.payara-p2-SNAPSHOT</version>
     </parent>
 
     <artifactId>json-ri-bundle</artifactId>

--- a/bundles/ri/pom.xml
+++ b/bundles/ri/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>json-bundles</artifactId>
-        <version>1.1.6.payara-p1-SNAPSHOT</version>
+        <version>1.1.6.payara-p1</version>
     </parent>
 
     <artifactId>json-ri-bundle</artifactId>

--- a/demos/customprovider-jdk9/pom.xml
+++ b/demos/customprovider-jdk9/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.jsonp</groupId>
         <artifactId>demos</artifactId>
-        <version>1.1.6.payara-p1-SNAPSHOT</version>
+        <version>1.1.6.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/customprovider-jdk9/pom.xml
+++ b/demos/customprovider-jdk9/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.jsonp</groupId>
         <artifactId>demos</artifactId>
-        <version>1.1.6.payara-p1</version>
+        <version>1.1.6.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/facebook/pom.xml
+++ b/demos/facebook/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.jsonp</groupId>
         <artifactId>demos</artifactId>
-        <version>1.1.6.payara-p1-SNAPSHOT</version>
+        <version>1.1.6.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/facebook/pom.xml
+++ b/demos/facebook/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.jsonp</groupId>
         <artifactId>demos</artifactId>
-        <version>1.1.6.payara-p1</version>
+        <version>1.1.6.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/jaxrs/pom.xml
+++ b/demos/jaxrs/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.jsonp</groupId>
         <artifactId>demos</artifactId>
-        <version>1.1.6.payara-p1-SNAPSHOT</version>
+        <version>1.1.6.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/jaxrs/pom.xml
+++ b/demos/jaxrs/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.jsonp</groupId>
         <artifactId>demos</artifactId>
-        <version>1.1.6.payara-p1</version>
+        <version>1.1.6.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/jsonpointer/pom.xml
+++ b/demos/jsonpointer/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.jsonp</groupId>
         <artifactId>demos</artifactId>
-        <version>1.1.6.payara-p1-SNAPSHOT</version>
+        <version>1.1.6.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/jsonpointer/pom.xml
+++ b/demos/jsonpointer/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.jsonp</groupId>
         <artifactId>demos</artifactId>
-        <version>1.1.6.payara-p1</version>
+        <version>1.1.6.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/pom.xml
+++ b/demos/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>json</artifactId>
-        <version>1.1.6.payara-p1</version>
+        <version>1.1.6.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/pom.xml
+++ b/demos/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>json</artifactId>
-        <version>1.1.6.payara-p1-SNAPSHOT</version>
+        <version>1.1.6.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/servlet/pom.xml
+++ b/demos/servlet/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.jsonp</groupId>
         <artifactId>demos</artifactId>
-        <version>1.1.6.payara-p1-SNAPSHOT</version>
+        <version>1.1.6.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/servlet/pom.xml
+++ b/demos/servlet/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.jsonp</groupId>
         <artifactId>demos</artifactId>
-        <version>1.1.6.payara-p1</version>
+        <version>1.1.6.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/twitter/pom.xml
+++ b/demos/twitter/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.jsonp</groupId>
         <artifactId>demos</artifactId>
-        <version>1.1.6.payara-p1-SNAPSHOT</version>
+        <version>1.1.6.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/demos/twitter/pom.xml
+++ b/demos/twitter/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.glassfish.jsonp</groupId>
         <artifactId>demos</artifactId>
-        <version>1.1.6.payara-p1</version>
+        <version>1.1.6.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/gf/customprovider/pom.xml
+++ b/gf/customprovider/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.jsonp</groupId>
         <artifactId>providers</artifactId>
-        <version>1.1.6.payara-p1</version>
+        <version>1.1.6.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/gf/customprovider/pom.xml
+++ b/gf/customprovider/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.jsonp</groupId>
         <artifactId>providers</artifactId>
-        <version>1.1.6.payara-p1-SNAPSHOT</version>
+        <version>1.1.6.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/gf/defaultprovider/pom.xml
+++ b/gf/defaultprovider/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.jsonp</groupId>
         <artifactId>providers</artifactId>
-        <version>1.1.6.payara-p1</version>
+        <version>1.1.6.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/gf/defaultprovider/pom.xml
+++ b/gf/defaultprovider/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish.jsonp</groupId>
         <artifactId>providers</artifactId>
-        <version>1.1.6.payara-p1-SNAPSHOT</version>
+        <version>1.1.6.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/gf/pom.xml
+++ b/gf/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>json</artifactId>
-        <version>1.1.6.payara-p1-SNAPSHOT</version>
+        <version>1.1.6.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/gf/pom.xml
+++ b/gf/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>json</artifactId>
-        <version>1.1.6.payara-p1</version>
+        <version>1.1.6.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -23,14 +23,14 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>json</artifactId>
-        <version>1.1.6.payara-p1</version>
+        <version>1.1.6.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <groupId>org.glassfish</groupId>
     <artifactId>jakarta.json</artifactId>
     <packaging>bundle</packaging>
-    <version>1.1.6.payara-p1</version>
+    <version>1.1.6.payara-p2-SNAPSHOT</version>
     <name>JSON-P Default Provider</name>
     <description>Default provider for Jakarta JSON Processing</description>
     <url>https://github.com/eclipse-ee4j/jsonp</url>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -23,14 +23,14 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>json</artifactId>
-        <version>1.1.6.payara-p1-SNAPSHOT</version>
+        <version>1.1.6.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <groupId>org.glassfish</groupId>
     <artifactId>jakarta.json</artifactId>
     <packaging>bundle</packaging>
-    <version>1.1.6.payara-p1-SNAPSHOT</version>
+    <version>1.1.6.payara-p1</version>
     <name>JSON-P Default Provider</name>
     <description>Default provider for Jakarta JSON Processing</description>
     <url>https://github.com/eclipse-ee4j/jsonp</url>

--- a/impl/src/main/java/org/glassfish/json/JsonArrayBuilderImpl.java
+++ b/impl/src/main/java/org/glassfish/json/JsonArrayBuilderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -35,23 +35,23 @@ import java.util.Optional;
  * @author Jitendra Kotamraju
  * @author Kin-man Chung
  */
-
 class JsonArrayBuilderImpl implements JsonArrayBuilder {
-    private ArrayList<JsonValue> valueList;
-    private final BufferPool bufferPool;
 
-    JsonArrayBuilderImpl(BufferPool bufferPool) {
-        this.bufferPool = bufferPool;
+    private ArrayList<JsonValue> valueList;
+    private final JsonContext jsonContext;
+
+    JsonArrayBuilderImpl(JsonContext jsonContext) {
+        this.jsonContext = jsonContext;
     }
 
-    JsonArrayBuilderImpl(JsonArray array, BufferPool bufferPool) {
-        this.bufferPool = bufferPool;
+    JsonArrayBuilderImpl(JsonArray array, JsonContext jsonContext) {
+        this(jsonContext);
         valueList = new ArrayList<>();
         valueList.addAll(array);
     }
 
-    JsonArrayBuilderImpl(Collection<?> collection, BufferPool bufferPool) {
-        this.bufferPool = bufferPool;
+    JsonArrayBuilderImpl(Collection<?> collection, JsonContext jsonContext) {
+        this(jsonContext);
         valueList = new ArrayList<>();
         populate(collection);
     }
@@ -73,32 +73,32 @@ class JsonArrayBuilderImpl implements JsonArrayBuilder {
     @Override
     public JsonArrayBuilder add(BigDecimal value) {
         validateValue(value);
-        addValueList(JsonNumberImpl.getJsonNumber(value));
+        addValueList(JsonNumberImpl.getJsonNumber(value, jsonContext.bigIntegerScaleLimit()));
         return this;
     }
 
     @Override
     public JsonArrayBuilder add(BigInteger value) {
         validateValue(value);
-        addValueList(JsonNumberImpl.getJsonNumber(value));
+        addValueList(JsonNumberImpl.getJsonNumber(value, jsonContext.bigIntegerScaleLimit()));
         return this;
     }
 
     @Override
     public JsonArrayBuilder add(int value) {
-        addValueList(JsonNumberImpl.getJsonNumber(value));
+        addValueList(JsonNumberImpl.getJsonNumber(value, jsonContext.bigIntegerScaleLimit()));
         return this;
     }
 
     @Override
     public JsonArrayBuilder add(long value) {
-        addValueList(JsonNumberImpl.getJsonNumber(value));
+        addValueList(JsonNumberImpl.getJsonNumber(value, jsonContext.bigIntegerScaleLimit()));
         return this;
     }
 
     @Override
     public JsonArrayBuilder add(double value) {
-        addValueList(JsonNumberImpl.getJsonNumber(value));
+        addValueList(JsonNumberImpl.getJsonNumber(value, jsonContext.bigIntegerScaleLimit()));
         return this;
     }
 
@@ -161,32 +161,32 @@ class JsonArrayBuilderImpl implements JsonArrayBuilder {
     @Override
     public JsonArrayBuilder add(int index, BigDecimal value) {
         validateValue(value);
-        addValueList(index, JsonNumberImpl.getJsonNumber(value));
+        addValueList(index, JsonNumberImpl.getJsonNumber(value, jsonContext.bigIntegerScaleLimit()));
         return this;
     }
 
     @Override
     public JsonArrayBuilder add(int index, BigInteger value) {
         validateValue(value);
-        addValueList(index, JsonNumberImpl.getJsonNumber(value));
+        addValueList(index, JsonNumberImpl.getJsonNumber(value, jsonContext.bigIntegerScaleLimit()));
         return this;
     }
 
     @Override
     public JsonArrayBuilder add(int index, int value) {
-        addValueList(index, JsonNumberImpl.getJsonNumber(value));
+        addValueList(index, JsonNumberImpl.getJsonNumber(value, jsonContext.bigIntegerScaleLimit()));
         return this;
     }
 
     @Override
     public JsonArrayBuilder add(int index, long value) {
-        addValueList(index, JsonNumberImpl.getJsonNumber(value));
+        addValueList(index, JsonNumberImpl.getJsonNumber(value, jsonContext.bigIntegerScaleLimit()));
         return this;
     }
 
     @Override
     public JsonArrayBuilder add(int index, double value) {
-        addValueList(index, JsonNumberImpl.getJsonNumber(value));
+        addValueList(index, JsonNumberImpl.getJsonNumber(value, jsonContext.bigIntegerScaleLimit()));
         return this;
     }
 
@@ -237,32 +237,32 @@ class JsonArrayBuilderImpl implements JsonArrayBuilder {
     @Override
     public JsonArrayBuilder set(int index, BigDecimal value) {
         validateValue(value);
-        setValueList(index, JsonNumberImpl.getJsonNumber(value));
+        setValueList(index, JsonNumberImpl.getJsonNumber(value, jsonContext.bigIntegerScaleLimit()));
         return this;
     }
 
     @Override
     public JsonArrayBuilder set(int index, BigInteger value) {
         validateValue(value);
-        setValueList(index, JsonNumberImpl.getJsonNumber(value));
+        setValueList(index, JsonNumberImpl.getJsonNumber(value, jsonContext.bigIntegerScaleLimit()));
         return this;
     }
 
     @Override
     public JsonArrayBuilder set(int index, int value) {
-        setValueList(index, JsonNumberImpl.getJsonNumber(value));
+        setValueList(index, JsonNumberImpl.getJsonNumber(value, jsonContext.bigIntegerScaleLimit()));
         return this;
     }
 
     @Override
     public JsonArrayBuilder set(int index, long value) {
-        setValueList(index, JsonNumberImpl.getJsonNumber(value));
+        setValueList(index, JsonNumberImpl.getJsonNumber(value, jsonContext.bigIntegerScaleLimit()));
         return this;
     }
 
     @Override
     public JsonArrayBuilder set(int index, double value) {
-        setValueList(index, JsonNumberImpl.getJsonNumber(value));
+        setValueList(index, JsonNumberImpl.getJsonNumber(value, jsonContext.bigIntegerScaleLimit()));
         return this;
     }
 
@@ -316,16 +316,16 @@ class JsonArrayBuilderImpl implements JsonArrayBuilder {
             snapshot = Collections.unmodifiableList(valueList);
         }
         valueList = null;
-        return new JsonArrayImpl(snapshot, bufferPool);
+        return new JsonArrayImpl(snapshot, jsonContext);
     }
 
     private void populate(Collection<?> collection) {
         for (Object value : collection) {
-            if (value != null && value instanceof Optional) {
+            if (value instanceof Optional) {
                 ((Optional<?>) value).ifPresent(v ->
-                        this.valueList.add(MapUtil.handle(v, bufferPool)));
+                        this.valueList.add(MapUtil.handle(v, jsonContext)));
             } else {
-                this.valueList.add(MapUtil.handle(value, bufferPool));
+                this.valueList.add(MapUtil.handle(value, jsonContext));
             }
         }
     }
@@ -359,11 +359,11 @@ class JsonArrayBuilderImpl implements JsonArrayBuilder {
 
     private static final class JsonArrayImpl extends AbstractList<JsonValue> implements JsonArray {
         private final List<JsonValue> valueList;    // Unmodifiable
-        private final BufferPool bufferPool;
+        private final JsonContext jsonContext;
 
-        JsonArrayImpl(List<JsonValue> valueList, BufferPool bufferPool) {
+        JsonArrayImpl(List<JsonValue> valueList, JsonContext jsonContext) {
             this.valueList = valueList;
-            this.bufferPool = bufferPool;
+            this.jsonContext = jsonContext;
         }
 
         @Override
@@ -464,7 +464,7 @@ class JsonArrayBuilderImpl implements JsonArrayBuilder {
         @Override
         public String toString() {
             StringWriter sw = new StringWriter();
-            try (JsonWriter jw = new JsonWriterImpl(sw, bufferPool)) {
+            try (JsonWriter jw = new JsonWriterImpl(sw, jsonContext)) {
                 jw.write(this);
             }
             return sw.toString();

--- a/impl/src/main/java/org/glassfish/json/JsonBuilderFactoryImpl.java
+++ b/impl/src/main/java/org/glassfish/json/JsonBuilderFactoryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,60 +17,58 @@
 package org.glassfish.json;
 
 import java.util.Collection;
-import org.glassfish.json.api.BufferPool;
 
 import javax.json.JsonObject;
 import javax.json.JsonArray;
 import javax.json.JsonArrayBuilder;
 import javax.json.JsonBuilderFactory;
 import javax.json.JsonObjectBuilder;
-import java.util.Collections;
 import java.util.Map;
 
 /**
  * @author Jitendra Kotamraju
  */
 class JsonBuilderFactoryImpl implements JsonBuilderFactory {
-    private final Map<String, ?> config;
-    private final BufferPool bufferPool;
 
-    JsonBuilderFactoryImpl(BufferPool bufferPool) {
-        this.config = Collections.emptyMap();
-        this.bufferPool = bufferPool;
+    private final JsonContext jsonContext;
+
+    JsonBuilderFactoryImpl(JsonContext jsonContext) {
+        this.jsonContext = jsonContext;
     }
 
     @Override
     public JsonObjectBuilder createObjectBuilder() {
-        return new JsonObjectBuilderImpl(bufferPool);
+        return new JsonObjectBuilderImpl(jsonContext);
     }
  
     @Override
     public JsonObjectBuilder createObjectBuilder(JsonObject object) {
-        return new JsonObjectBuilderImpl(object, bufferPool);
+        return new JsonObjectBuilderImpl(object, jsonContext);
     }
 
     @Override
     public JsonObjectBuilder createObjectBuilder(Map<String, Object> object) {
-        return new JsonObjectBuilderImpl(object, bufferPool);
+        return new JsonObjectBuilderImpl(object, jsonContext);
     }
 
     @Override
     public JsonArrayBuilder createArrayBuilder() {
-        return new JsonArrayBuilderImpl(bufferPool);
+        return new JsonArrayBuilderImpl(jsonContext);
     }
 
     @Override
     public JsonArrayBuilder createArrayBuilder(JsonArray array) {
-        return new JsonArrayBuilderImpl(array, bufferPool);
+        return new JsonArrayBuilderImpl(array, jsonContext);
     }
 
     @Override
     public JsonArrayBuilder createArrayBuilder(Collection<?> collection) {
-        return new JsonArrayBuilderImpl(collection, bufferPool);
+        return new JsonArrayBuilderImpl(collection, jsonContext);
     }
 
     @Override
     public Map<String, ?> getConfigInUse() {
-        return config;
+        return jsonContext.config();
     }
+
 }

--- a/impl/src/main/java/org/glassfish/json/JsonContext.java
+++ b/impl/src/main/java/org/glassfish/json/JsonContext.java
@@ -35,7 +35,10 @@ import org.glassfish.json.api.JsonConfig;
 final class JsonContext {
 
     /** Default maximum value of BigInteger scale value limit. */
-    private static final int DEFAULT_MAX_BIGINT_SCALE = 100000;
+    private static final int DEFAULT_MAX_BIGINTEGER_SCALE = 100000;
+
+    /** Default maximum number of characters of BigDecimal source being parsed. */
+    private static final int DEFAULT_MAX_BIGDECIMAL_LEN = 1100;
 
     /**
      * Custom char[] pool instance property. Can be set in properties {@code Map} only.
@@ -46,6 +49,9 @@ final class JsonContext {
 
     // Maximum value of BigInteger scale value
     private final int bigIntegerScaleLimit;
+
+    // Maximum number of characters of BigDecimal source
+    private final int bigDecimalLengthLimit;
 
     // Whether JSON pretty printing is enabled
     private final boolean prettyPrinting;
@@ -59,7 +65,8 @@ final class JsonContext {
      * @param defaultPool default char[] pool to use when no instance is configured
      */
     JsonContext(Map<String, ?> config, BufferPool defaultPool) {
-        this.bigIntegerScaleLimit = getIntConfig(JsonConfig.MAX_BIGINT_SCALE, config, DEFAULT_MAX_BIGINT_SCALE);
+        this.bigIntegerScaleLimit = getIntConfig(JsonConfig.MAX_BIGINTEGER_SCALE, config, DEFAULT_MAX_BIGINTEGER_SCALE);
+        this.bigDecimalLengthLimit = getIntConfig(JsonConfig.MAX_BIGDECIMAL_LEN, config, DEFAULT_MAX_BIGDECIMAL_LEN);
         this.prettyPrinting = getBooleanConfig(JsonGenerator.PRETTY_PRINTING, config);
         this.bufferPool = getBufferPool(config, defaultPool);
         this.config = config != null ? Collections.unmodifiableMap(config) : null;
@@ -73,7 +80,8 @@ final class JsonContext {
      * @param properties properties to store in local copy of provider specific properties {@code Map}
      */
     JsonContext(Map<String, ?> config, BufferPool defaultPool, String... properties) {
-        this.bigIntegerScaleLimit = getIntConfig(JsonConfig.MAX_BIGINT_SCALE, config, DEFAULT_MAX_BIGINT_SCALE);
+        this.bigIntegerScaleLimit = getIntConfig(JsonConfig.MAX_BIGINTEGER_SCALE, config, DEFAULT_MAX_BIGINTEGER_SCALE);
+        this.bigDecimalLengthLimit = getIntConfig(JsonConfig.MAX_BIGDECIMAL_LEN, config, DEFAULT_MAX_BIGDECIMAL_LEN);
         this.prettyPrinting = getBooleanConfig(JsonGenerator.PRETTY_PRINTING, config);
         this.bufferPool = getBufferPool(config, defaultPool);
         this.config = config != null
@@ -90,6 +98,10 @@ final class JsonContext {
 
     int bigIntegerScaleLimit() {
         return bigIntegerScaleLimit;
+    }
+
+    int bigDecimalLengthLimit() {
+        return bigDecimalLengthLimit;
     }
 
     boolean prettyPrinting() {

--- a/impl/src/main/java/org/glassfish/json/JsonContext.java
+++ b/impl/src/main/java/org/glassfish/json/JsonContext.java
@@ -40,6 +40,9 @@ final class JsonContext {
     /** Default maximum number of characters of BigDecimal source being parsed. */
     private static final int DEFAULT_MAX_BIGDECIMAL_LEN = 1100;
 
+    /** Default maximum level of nesting. */
+    private static final int DEFAULT_MAX_DEPTH = 1000;
+
     /**
      * Custom char[] pool instance property. Can be set in properties {@code Map} only.
      */
@@ -52,6 +55,9 @@ final class JsonContext {
 
     // Maximum number of characters of BigDecimal source
     private final int bigDecimalLengthLimit;
+
+    // Maximum depth to parse
+    private final int depthLimit;
 
     // Whether JSON pretty printing is enabled
     private final boolean prettyPrinting;
@@ -67,6 +73,7 @@ final class JsonContext {
     JsonContext(Map<String, ?> config, BufferPool defaultPool) {
         this.bigIntegerScaleLimit = getIntConfig(JsonConfig.MAX_BIGINTEGER_SCALE, config, DEFAULT_MAX_BIGINTEGER_SCALE);
         this.bigDecimalLengthLimit = getIntConfig(JsonConfig.MAX_BIGDECIMAL_LEN, config, DEFAULT_MAX_BIGDECIMAL_LEN);
+        this.depthLimit = getIntConfig(JsonConfig.MAX_DEPTH, config, DEFAULT_MAX_DEPTH);
         this.prettyPrinting = getBooleanConfig(JsonGenerator.PRETTY_PRINTING, config);
         this.bufferPool = getBufferPool(config, defaultPool);
         this.config = config != null ? Collections.unmodifiableMap(config) : null;
@@ -82,6 +89,7 @@ final class JsonContext {
     JsonContext(Map<String, ?> config, BufferPool defaultPool, String... properties) {
         this.bigIntegerScaleLimit = getIntConfig(JsonConfig.MAX_BIGINTEGER_SCALE, config, DEFAULT_MAX_BIGINTEGER_SCALE);
         this.bigDecimalLengthLimit = getIntConfig(JsonConfig.MAX_BIGDECIMAL_LEN, config, DEFAULT_MAX_BIGDECIMAL_LEN);
+        this.depthLimit = getIntConfig(JsonConfig.MAX_DEPTH, config, DEFAULT_MAX_DEPTH);
         this.prettyPrinting = getBooleanConfig(JsonGenerator.PRETTY_PRINTING, config);
         this.bufferPool = getBufferPool(config, defaultPool);
         this.config = config != null
@@ -102,6 +110,10 @@ final class JsonContext {
 
     int bigDecimalLengthLimit() {
         return bigDecimalLengthLimit;
+    }
+
+    int depthLimit() {
+        return depthLimit;
     }
 
     boolean prettyPrinting() {

--- a/impl/src/main/java/org/glassfish/json/JsonContext.java
+++ b/impl/src/main/java/org/glassfish/json/JsonContext.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.json;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import javax.json.JsonException;
+import javax.json.stream.JsonGenerator;
+import org.glassfish.json.api.BufferPool;
+import org.glassfish.json.api.JsonConfig;
+
+/**
+ * Parsson configuration.
+ * Values are composed from properties {@code Map}, system properties and default value.
+ */
+final class JsonContext {
+
+    /** Default maximum value of BigInteger scale value limit. */
+    private static final int DEFAULT_MAX_BIGINT_SCALE = 100000;
+
+    /**
+     * Custom char[] pool instance property. Can be set in properties {@code Map} only.
+     */
+    static final String PROPERTY_BUFFER_POOL = BufferPool.class.getName();
+
+    private final Map<String, ?> config;
+
+    // Maximum value of BigInteger scale value
+    private final int bigIntegerScaleLimit;
+
+    // Whether JSON pretty printing is enabled
+    private final boolean prettyPrinting;
+
+    private final BufferPool bufferPool;
+
+    /**
+     * Creates an instance of Parsson configuration.
+     *
+     * @param config a {@code Map} of provider specific properties to configure the JSON parsers
+     * @param defaultPool default char[] pool to use when no instance is configured
+     */
+    JsonContext(Map<String, ?> config, BufferPool defaultPool) {
+        this.bigIntegerScaleLimit = getIntConfig(JsonConfig.MAX_BIGINT_SCALE, config, DEFAULT_MAX_BIGINT_SCALE);
+        this.prettyPrinting = getBooleanConfig(JsonGenerator.PRETTY_PRINTING, config);
+        this.bufferPool = getBufferPool(config, defaultPool);
+        this.config = config != null ? Collections.unmodifiableMap(config) : null;
+    }
+
+    /**
+     * Creates an instance of Parsson configuration.
+     *
+     * @param config a map of provider specific properties to configure the JSON parsers
+     * @param defaultPool default char[] pool to use when no instance is configured
+     * @param properties properties to store in local copy of provider specific properties {@code Map}
+     */
+    JsonContext(Map<String, ?> config, BufferPool defaultPool, String... properties) {
+        this.bigIntegerScaleLimit = getIntConfig(JsonConfig.MAX_BIGINT_SCALE, config, DEFAULT_MAX_BIGINT_SCALE);
+        this.prettyPrinting = getBooleanConfig(JsonGenerator.PRETTY_PRINTING, config);
+        this.bufferPool = getBufferPool(config, defaultPool);
+        this.config = config != null
+                ? Collections.unmodifiableMap(copyPropertiesMap(this, config, properties)) : null;
+    }
+
+    Map<String, ?> config() {
+        return config;
+    }
+
+    Object config(String propertyName) {
+        return config != null ? config.get(propertyName) : null;
+    }
+
+    int bigIntegerScaleLimit() {
+        return bigIntegerScaleLimit;
+    }
+
+    boolean prettyPrinting() {
+        return prettyPrinting;
+    }
+
+    BufferPool bufferPool() {
+        return bufferPool;
+    }
+
+    private static BufferPool getBufferPool(Map<String, ?> config, BufferPool defaultrPool) {
+        BufferPool pool = config != null ? (BufferPool)config.get(PROPERTY_BUFFER_POOL) : null;
+        return pool != null ? pool : defaultrPool;
+    }
+
+    private static int getIntConfig(String propertyName, Map<String, ?> config, int defaultValue) throws JsonException {
+        // Try config Map first
+        Integer intConfig = config != null ? getIntProperty(propertyName, config) : null;
+        if (intConfig != null) {
+            return intConfig;
+        }
+        // Try system properties as fallback.
+        intConfig = getIntSystemProperty(propertyName);
+        return intConfig != null ? intConfig : defaultValue;
+    }
+
+    private static boolean getBooleanConfig(String propertyName, Map<String, ?> config) throws JsonException {
+        // Try config Map first
+        Boolean booleanConfig = config != null ? getBooleanProperty(propertyName, config) : null;
+        if (booleanConfig != null) {
+            return booleanConfig;
+        }
+        // Try system properties as fallback.
+        return getBooleanSystemProperty(propertyName);
+    }
+
+    private static Integer getIntProperty(String propertyName, Map<String, ?> config) throws JsonException {
+        Object property = config.get(propertyName);
+        if (property == null) {
+            return null;
+        }
+        if (property instanceof Number) {
+            return ((Number) property).intValue();
+        }
+        if (property instanceof String) {
+            return propertyStringToInt(propertyName, (String) property);
+        }
+        throw new JsonException(
+                String.format("Could not convert %s property of type %s to Integer",
+                              propertyName, property.getClass().getName()));
+    }
+
+    // Returns true when property exists or null otherwise. Property value is ignored.
+    private static Boolean getBooleanProperty(String propertyName, Map<String, ?> config) throws JsonException {
+        return config.containsKey(propertyName) ? true : null;
+    }
+
+
+    private static Integer getIntSystemProperty(String propertyName) throws JsonException {
+        String systemProperty = getSystemProperty(propertyName);
+        if (systemProperty == null) {
+            return null;
+        }
+        return propertyStringToInt(propertyName, systemProperty);
+    }
+
+    // Returns true when property exists or false otherwise. Property value is ignored.
+    private static boolean getBooleanSystemProperty(String propertyName) throws JsonException {
+        return getSystemProperty(propertyName) != null;
+    }
+
+    @SuppressWarnings("removal")
+    private static String getSystemProperty(String propertyName) throws JsonException {
+        if (System.getSecurityManager() != null) {
+            return AccessController.doPrivileged(
+                    (PrivilegedAction<String>) () -> System.getProperty(propertyName));
+        } else {
+            return System.getProperty(propertyName);
+        }
+    }
+
+    private static int propertyStringToInt(String propertyName, String propertyValue) throws JsonException {
+        try {
+            return Integer.parseInt(propertyValue);
+        } catch (NumberFormatException ex) {
+            throw new JsonException(
+                    String.format("Value of %s property is not a number", propertyName), ex);
+        }
+    }
+
+    // Constructor helper: Copy provider specific properties Map. Only specified properties are added.
+    // Instance prettyPrinting and rejectDuplicateKeys variables must be initialized before
+    // this method is called.
+    private static Map<String, ?> copyPropertiesMap(JsonContext instance, Map<String, ?> config, String... properties) {
+        Objects.requireNonNull(config, "Map of provider specific properties is null");
+        if (properties == null || properties.length == 0) {
+            return Collections.emptyMap();
+        }
+        Map<String, Object> newConfig = new HashMap<>(properties.length);
+        for (String propertyName : properties) {
+            switch (propertyName) {
+                // Some properties need special handling.
+                case JsonGenerator.PRETTY_PRINTING:
+                    if (instance.prettyPrinting) {
+                        newConfig.put(JsonGenerator.PRETTY_PRINTING, true);
+                    }
+                    break;
+                // Rest of properties are copied without changes
+                default:
+                    if (config.containsKey(propertyName)) {
+                        newConfig.put(propertyName, config.get(propertyName));
+                    }
+            }
+        }
+        return newConfig;
+    }
+
+}

--- a/impl/src/main/java/org/glassfish/json/JsonGeneratorFactoryImpl.java
+++ b/impl/src/main/java/org/glassfish/json/JsonGeneratorFactoryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,8 +16,6 @@
 
 package org.glassfish.json;
 
-import org.glassfish.json.api.BufferPool;
-
 import javax.json.stream.JsonGenerator;
 import javax.json.stream.JsonGeneratorFactory;
 import java.io.OutputStream;
@@ -30,41 +28,36 @@ import java.util.Map;
  */
 class JsonGeneratorFactoryImpl implements JsonGeneratorFactory {
 
-    private final boolean prettyPrinting;
-    private final Map<String, ?> config;    // unmodifiable map
-    private final BufferPool bufferPool;
+    private final JsonContext jsonContext;
 
-    JsonGeneratorFactoryImpl(Map<String, ?> config, boolean prettyPrinting,
-            BufferPool bufferPool) {
-        this.config = config;
-        this.prettyPrinting = prettyPrinting;
-        this.bufferPool = bufferPool;
+    JsonGeneratorFactoryImpl(JsonContext jsonContext) {
+        this.jsonContext = jsonContext;
     }
 
     @Override
     public JsonGenerator createGenerator(Writer writer) {
-        return prettyPrinting
-                ? new JsonPrettyGeneratorImpl(writer, bufferPool)
-                : new JsonGeneratorImpl(writer, bufferPool);
+        return jsonContext.prettyPrinting()
+                ? new JsonPrettyGeneratorImpl(writer, jsonContext)
+                : new JsonGeneratorImpl(writer, jsonContext);
     }
 
     @Override
     public JsonGenerator createGenerator(OutputStream out) {
-        return prettyPrinting
-                ? new JsonPrettyGeneratorImpl(out, bufferPool)
-                : new JsonGeneratorImpl(out, bufferPool);
+        return jsonContext.prettyPrinting()
+                ? new JsonPrettyGeneratorImpl(out, jsonContext)
+                : new JsonGeneratorImpl(out, jsonContext);
     }
 
     @Override
     public JsonGenerator createGenerator(OutputStream out, Charset charset) {
-        return prettyPrinting
-                ? new JsonPrettyGeneratorImpl(out, charset, bufferPool)
-                : new JsonGeneratorImpl(out, charset, bufferPool);
+        return jsonContext.prettyPrinting()
+                ? new JsonPrettyGeneratorImpl(out, charset, jsonContext)
+                : new JsonGeneratorImpl(out, charset, jsonContext);
     }
 
     @Override
     public Map<String, ?> getConfigInUse() {
-        return config;
+        return jsonContext.config();
     }
 
 }

--- a/impl/src/main/java/org/glassfish/json/JsonGeneratorImpl.java
+++ b/impl/src/main/java/org/glassfish/json/JsonGeneratorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -91,18 +91,18 @@ class JsonGeneratorImpl implements JsonGenerator {
     private final char buf[];     // capacity >= INT_MIN_VALUE_CHARS.length
     private int len = 0;
 
-    JsonGeneratorImpl(Writer writer, BufferPool bufferPool) {
+    JsonGeneratorImpl(Writer writer, JsonContext jsonContext) {
+        this.bufferPool = jsonContext.bufferPool();
         this.writer = writer;
-        this.bufferPool = bufferPool;
-        this.buf = bufferPool.take();
+        this.buf = jsonContext.bufferPool().take();
     }
 
-    JsonGeneratorImpl(OutputStream out, BufferPool bufferPool) {
-        this(out, StandardCharsets.UTF_8, bufferPool);
+    JsonGeneratorImpl(OutputStream out, JsonContext jsonContext) {
+        this(out, StandardCharsets.UTF_8, jsonContext);
     }
 
-    JsonGeneratorImpl(OutputStream out, Charset encoding, BufferPool bufferPool) {
-        this(new OutputStreamWriter(out, encoding), bufferPool);
+    JsonGeneratorImpl(OutputStream out, Charset encoding, JsonContext jsonContext) {
+        this(new OutputStreamWriter(out, encoding), jsonContext);
     }
 
     @Override

--- a/impl/src/main/java/org/glassfish/json/JsonMessages.java
+++ b/impl/src/main/java/org/glassfish/json/JsonMessages.java
@@ -117,6 +117,10 @@ final class JsonMessages {
         return localize("parser.input.enc.detect.ioerr");
     }
 
+    static String PARSER_INPUT_NESTED_TOO_DEEP(int limit) {
+        return localize("parser.input.nested.too.deep", limit);
+    }
+
     // generator messages
     static String GENERATOR_FLUSH_IO_ERR() {
         return localize("generator.flush.io.err");
@@ -158,6 +162,10 @@ final class JsonMessages {
         return localize("reader.read.already.called");
     }
 
+    // JSON number messages
+    static String NUMBER_SCALE_LIMIT_EXCEPTION(int value, int limit) {
+        return localize("number.scale.limit.exception", value, limit);
+    }
 
     // obj builder messages
     static String OBJBUILDER_NAME_NULL() {

--- a/impl/src/main/java/org/glassfish/json/JsonNumberImpl.java
+++ b/impl/src/main/java/org/glassfish/json/JsonNumberImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -28,26 +28,39 @@ import java.math.BigInteger;
  */
 abstract class JsonNumberImpl implements JsonNumber {
 
-    static JsonNumber getJsonNumber(int num) {
-        return new JsonIntNumber(num);
+    private int hashCode;
+    private final int bigIntegerScaleLimit;
+
+    JsonNumberImpl(int bigIntegerScaleLimit) {
+        this.bigIntegerScaleLimit = bigIntegerScaleLimit;
     }
 
-    static JsonNumber getJsonNumber(long num) {
-        return new JsonLongNumber(num);
+    static JsonNumber getJsonNumber(int num, int bigIntegerScaleLimit) {
+        return new JsonIntNumber(num, bigIntegerScaleLimit);
     }
 
-    static JsonNumber getJsonNumber(BigInteger value) {
-        return new JsonBigDecimalNumber(new BigDecimal(value));
+    static JsonNumber getJsonNumber(long num, int bigIntegerScaleLimit) {
+        return new JsonLongNumber(num, bigIntegerScaleLimit);
     }
 
-    static JsonNumber getJsonNumber(double value) {
+    static JsonNumber getJsonNumber(BigInteger value, int bigIntegerScaleLimit) {
+        if (value == null) {
+            throw new NullPointerException("Value is null");
+        }
+        return new JsonBigDecimalNumber(new BigDecimal(value), bigIntegerScaleLimit);
+    }
+
+    static JsonNumber getJsonNumber(double value, int bigIntegerScaleLimit) {
         //bigDecimal = new BigDecimal(value);
         // This is the preferred way to convert double to BigDecimal
-        return new JsonBigDecimalNumber(BigDecimal.valueOf(value));
+        return new JsonBigDecimalNumber(BigDecimal.valueOf(value), bigIntegerScaleLimit);
     }
 
-    static JsonNumber getJsonNumber(BigDecimal value) {
-        return new JsonBigDecimalNumber(value);
+    static JsonNumber getJsonNumber(BigDecimal value, int bigIntegerScaleLimit) {
+        if (value == null) {
+            throw new NullPointerException("Value is null");
+        }
+        return new JsonBigDecimalNumber(value, bigIntegerScaleLimit);
     }
 
     // Optimized JsonNumber impl for int numbers.
@@ -55,7 +68,8 @@ abstract class JsonNumberImpl implements JsonNumber {
         private final int num;
         private BigDecimal bigDecimal;  // assigning it lazily on demand
 
-        JsonIntNumber(int num) {
+        JsonIntNumber(int num, int bigIntegerScaleLimit) {
+            super(bigIntegerScaleLimit);
             this.num = num;
         }
 
@@ -116,7 +130,8 @@ abstract class JsonNumberImpl implements JsonNumber {
         private final long num;
         private BigDecimal bigDecimal;  // assigning it lazily on demand
 
-        JsonLongNumber(long num) {
+        JsonLongNumber(long num, int bigIntegerScaleLimit) {
+            super(bigIntegerScaleLimit);
             this.num = num;
         }
 
@@ -177,7 +192,8 @@ abstract class JsonNumberImpl implements JsonNumber {
     private static final class JsonBigDecimalNumber extends JsonNumberImpl {
         private final BigDecimal bigDecimal;
 
-        JsonBigDecimalNumber(BigDecimal value) {
+        JsonBigDecimalNumber(BigDecimal value, int bigIntegerScaleLimit) {
+            super(bigIntegerScaleLimit);
             this.bigDecimal = value;
         }
 
@@ -225,12 +241,26 @@ abstract class JsonNumberImpl implements JsonNumber {
 
     @Override
     public BigInteger bigIntegerValue() {
-        return bigDecimalValue().toBigInteger();
+        BigDecimal bd = bigDecimalValue();
+        if (bd.scale() <= bigIntegerScaleLimit) {
+            return bd.toBigInteger();
+        }
+        throw new UnsupportedOperationException(
+                String.format(
+                        "Scale value %d of this BigInteger exceeded maximal allowed value of %d",
+                        bd.scale(), bigIntegerScaleLimit));
     }
 
     @Override
     public BigInteger bigIntegerValueExact() {
-        return bigDecimalValue().toBigIntegerExact();
+        BigDecimal bd = bigDecimalValue();
+        if (bd.scale() <= bigIntegerScaleLimit) {
+            return bd.toBigIntegerExact();
+        }
+        throw new UnsupportedOperationException(
+                String.format(
+                        "Scale value %d of this BigInteger exceeded maximal allowed value of %d",
+                        bd.scale(), bigIntegerScaleLimit));
     }
 
     @Override
@@ -261,4 +291,3 @@ abstract class JsonNumberImpl implements JsonNumber {
     }
 
 }
-

--- a/impl/src/main/java/org/glassfish/json/JsonNumberImpl.java
+++ b/impl/src/main/java/org/glassfish/json/JsonNumberImpl.java
@@ -242,25 +242,21 @@ abstract class JsonNumberImpl implements JsonNumber {
     @Override
     public BigInteger bigIntegerValue() {
         BigDecimal bd = bigDecimalValue();
-        if (bd.scale() <= bigIntegerScaleLimit) {
+        if (Math.abs(bd.scale()) <= bigIntegerScaleLimit) {
             return bd.toBigInteger();
         }
         throw new UnsupportedOperationException(
-                String.format(
-                        "Scale value %d of this BigInteger exceeded maximal allowed value of %d",
-                        bd.scale(), bigIntegerScaleLimit));
+                JsonMessages.NUMBER_SCALE_LIMIT_EXCEPTION(bd.scale(), bigIntegerScaleLimit));
     }
 
     @Override
     public BigInteger bigIntegerValueExact() {
         BigDecimal bd = bigDecimalValue();
-        if (bd.scale() <= bigIntegerScaleLimit) {
+        if (Math.abs(bd.scale()) <= bigIntegerScaleLimit) {
             return bd.toBigIntegerExact();
         }
         throw new UnsupportedOperationException(
-                String.format(
-                        "Scale value %d of this BigInteger exceeded maximal allowed value of %d",
-                        bd.scale(), bigIntegerScaleLimit));
+                JsonMessages.NUMBER_SCALE_LIMIT_EXCEPTION(bd.scale(), bigIntegerScaleLimit));
     }
 
     @Override

--- a/impl/src/main/java/org/glassfish/json/JsonParserFactoryImpl.java
+++ b/impl/src/main/java/org/glassfish/json/JsonParserFactoryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,7 +16,6 @@
 
 package org.glassfish.json;
 
-import org.glassfish.json.api.BufferPool;
 
 import javax.json.JsonArray;
 import javax.json.JsonObject;
@@ -25,33 +24,32 @@ import javax.json.stream.JsonParser;
 import java.io.InputStream;
 import java.io.Reader;
 import java.nio.charset.Charset;
-import java.util.Collections;
 import java.util.Map;
 
 /**
  * @author Jitendra Kotamraju
  */
 class JsonParserFactoryImpl implements JsonParserFactory {
-    private final Map<String, ?> config = Collections.emptyMap();
-    private final BufferPool bufferPool;
 
-    JsonParserFactoryImpl(BufferPool bufferPool) {
-        this.bufferPool = bufferPool;
+    private final JsonContext jsonContext;
+
+    JsonParserFactoryImpl(JsonContext jsonContext) {
+        this.jsonContext = jsonContext;
     }
 
     @Override
     public JsonParser createParser(Reader reader) {
-        return new JsonParserImpl(reader, bufferPool);
+        return new JsonParserImpl(reader, jsonContext);
     }
 
     @Override
     public JsonParser createParser(InputStream in) {
-        return new JsonParserImpl(in, bufferPool);
+        return new JsonParserImpl(in, jsonContext);
     }
 
     @Override
     public JsonParser createParser(InputStream in, Charset charset) {
-        return new JsonParserImpl(in, charset, bufferPool);
+        return new JsonParserImpl(in, charset, jsonContext);
     }
 
     @Override
@@ -61,7 +59,7 @@ class JsonParserFactoryImpl implements JsonParserFactory {
 
     @Override
     public Map<String, ?> getConfigInUse() {
-        return config;
+        return jsonContext.config();
     }
 
     @Override

--- a/impl/src/main/java/org/glassfish/json/JsonParserImpl.java
+++ b/impl/src/main/java/org/glassfish/json/JsonParserImpl.java
@@ -42,7 +42,6 @@ import javax.json.stream.JsonParser;
 import javax.json.stream.JsonParsingException;
 
 import org.glassfish.json.JsonTokenizer.JsonToken;
-import org.glassfish.json.api.BufferPool;
 
 /**
  * JSON parser implementation. NoneContext, ArrayContext, ObjectContext is used
@@ -377,7 +376,7 @@ public class JsonParserImpl implements JsonParser {
 
         private void push(Context context) {
             if (++size >= limit) {
-                throw new RuntimeException("Input is too deeply nested " + size);
+                throw new RuntimeException(JsonMessages.PARSER_INPUT_NESTED_TOO_DEEP(size));
             }
             context.next = head;
             head = context;

--- a/impl/src/main/java/org/glassfish/json/JsonParserImpl.java
+++ b/impl/src/main/java/org/glassfish/json/JsonParserImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -39,7 +39,6 @@ import javax.json.JsonObjectBuilder;
 import javax.json.JsonValue;
 import javax.json.stream.JsonLocation;
 import javax.json.stream.JsonParser;
-import javax.json.stream.JsonParser.Event;
 import javax.json.stream.JsonParsingException;
 
 import org.glassfish.json.JsonTokenizer.JsonToken;
@@ -54,27 +53,28 @@ import org.glassfish.json.api.BufferPool;
  */
 public class JsonParserImpl implements JsonParser {
 
-    private final BufferPool bufferPool;
     private Context currentContext = new NoneContext();
     private Event currentEvent;
 
     private final Stack stack = new Stack();
     private final JsonTokenizer tokenizer;
 
-    public JsonParserImpl(Reader reader, BufferPool bufferPool) {
-        this.bufferPool = bufferPool;
-        tokenizer = new JsonTokenizer(reader, bufferPool);
+    private final JsonContext jsonContext;
+
+    public JsonParserImpl(Reader reader, JsonContext jsonContext) {
+        this.jsonContext = jsonContext;
+        this.tokenizer = new JsonTokenizer(reader, jsonContext);
     }
 
-    public JsonParserImpl(InputStream in, BufferPool bufferPool) {
-        this.bufferPool = bufferPool;
+    public JsonParserImpl(InputStream in, JsonContext jsonContext) {
+        this.jsonContext = jsonContext;
         UnicodeDetectingInputStream uin = new UnicodeDetectingInputStream(in);
-        tokenizer = new JsonTokenizer(new InputStreamReader(uin, uin.getCharset()), bufferPool);
+        this.tokenizer = new JsonTokenizer(new InputStreamReader(uin, uin.getCharset()), jsonContext);
     }
 
-    public JsonParserImpl(InputStream in, Charset encoding, BufferPool bufferPool) {
-        this.bufferPool = bufferPool;
-        tokenizer = new JsonTokenizer(new InputStreamReader(in, encoding), bufferPool);
+    public JsonParserImpl(InputStream in, Charset encoding, JsonContext jsonContext) {
+        this.jsonContext = jsonContext;
+        this.tokenizer = new JsonTokenizer(new InputStreamReader(in, encoding), jsonContext);
     }
 
     @Override
@@ -137,7 +137,7 @@ public class JsonParserImpl implements JsonParser {
             throw new IllegalStateException(
                 JsonMessages.PARSER_GETARRAY_ERR(currentEvent));
         }
-        return getArray(new JsonArrayBuilderImpl(bufferPool));
+        return getArray(new JsonArrayBuilderImpl(jsonContext));
     }
 
     @Override
@@ -146,26 +146,26 @@ public class JsonParserImpl implements JsonParser {
             throw new IllegalStateException(
                 JsonMessages.PARSER_GETOBJECT_ERR(currentEvent));
         }
-        return getObject(new JsonObjectBuilderImpl(bufferPool));
+        return getObject(new JsonObjectBuilderImpl(jsonContext));
     }
 
     @Override
     public JsonValue getValue() {
         switch (currentEvent) {
             case START_ARRAY:
-                return getArray(new JsonArrayBuilderImpl(bufferPool));
+                return getArray(new JsonArrayBuilderImpl(jsonContext));
             case START_OBJECT:
-                return getObject(new JsonObjectBuilderImpl(bufferPool));
+                return getObject(new JsonObjectBuilderImpl(jsonContext));
             case KEY_NAME:
             case VALUE_STRING:
                 return new JsonStringImpl(getString());
             case VALUE_NUMBER:
                 if (isDefinitelyInt()) {
-                    return JsonNumberImpl.getJsonNumber(getInt());
+                    return JsonNumberImpl.getJsonNumber(getInt(), jsonContext.bigIntegerScaleLimit());
                 } else if (isDefinitelyLong()) {
-                    return JsonNumberImpl.getJsonNumber(getLong());
+                    return JsonNumberImpl.getJsonNumber(getLong(), jsonContext.bigIntegerScaleLimit());
                 }
-                return JsonNumberImpl.getJsonNumber(getBigDecimal());
+                return JsonNumberImpl.getJsonNumber(getBigDecimal(), jsonContext.bigIntegerScaleLimit());
             case VALUE_TRUE:
                 return JsonValue.TRUE;
             case VALUE_FALSE:
@@ -389,7 +389,7 @@ public class JsonParserImpl implements JsonParser {
         }
     }
 
-    private abstract class Context {
+    private abstract static class Context {
         Context next;
         abstract Event getNextEvent();
         abstract void skip();

--- a/impl/src/main/java/org/glassfish/json/JsonParserImpl.java
+++ b/impl/src/main/java/org/glassfish/json/JsonParserImpl.java
@@ -56,24 +56,27 @@ public class JsonParserImpl implements JsonParser {
     private Context currentContext = new NoneContext();
     private Event currentEvent;
 
-    private final Stack stack = new Stack();
+    private final Stack stack;
     private final JsonTokenizer tokenizer;
 
     private final JsonContext jsonContext;
 
     public JsonParserImpl(Reader reader, JsonContext jsonContext) {
         this.jsonContext = jsonContext;
+        stack = new Stack(jsonContext.depthLimit());
         this.tokenizer = new JsonTokenizer(reader, jsonContext);
     }
 
     public JsonParserImpl(InputStream in, JsonContext jsonContext) {
         this.jsonContext = jsonContext;
+        stack = new Stack(jsonContext.depthLimit());
         UnicodeDetectingInputStream uin = new UnicodeDetectingInputStream(in);
         this.tokenizer = new JsonTokenizer(new InputStreamReader(uin, uin.getCharset()), jsonContext);
     }
 
     public JsonParserImpl(InputStream in, Charset encoding, JsonContext jsonContext) {
         this.jsonContext = jsonContext;
+        stack = new Stack(jsonContext.depthLimit());
         this.tokenizer = new JsonTokenizer(new InputStreamReader(in, encoding), jsonContext);
     }
 
@@ -364,9 +367,18 @@ public class JsonParserImpl implements JsonParser {
     // Using the optimized stack impl as we don't require other things
     // like iterator etc.
     private static final class Stack {
+        int size = 0;
+        final int limit;
         private Context head;
 
+        Stack(int size) {
+            this.limit = size;
+        }
+
         private void push(Context context) {
+            if (++size >= limit) {
+                throw new RuntimeException("Input is too deeply nested " + size);
+            }
             context.next = head;
             head = context;
         }
@@ -375,6 +387,7 @@ public class JsonParserImpl implements JsonParser {
             if (head == null) {
                 throw new NoSuchElementException();
             }
+            size--;
             Context temp = head;
             head = head.next;
             return temp;

--- a/impl/src/main/java/org/glassfish/json/JsonPatchBuilderImpl.java
+++ b/impl/src/main/java/org/glassfish/json/JsonPatchBuilderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,7 +16,6 @@
 
 package org.glassfish.json;
 
-import javax.json.Json;
 import javax.json.JsonArray;
 import javax.json.JsonArrayBuilder;
 import javax.json.JsonException;
@@ -48,6 +47,7 @@ import javax.json.JsonValue;
  */
 public final class JsonPatchBuilderImpl implements JsonPatchBuilder {
 
+    private final JsonContext jsonContext;
     private final JsonArrayBuilder builder;
 
     /**
@@ -55,15 +55,17 @@ public final class JsonPatchBuilderImpl implements JsonPatchBuilder {
      * JSON Patch
      * @param patch the JSON Patch
      */
-    public JsonPatchBuilderImpl(JsonArray patch) {
-        builder = Json.createArrayBuilder(patch);
+    public JsonPatchBuilderImpl(JsonArray patch, JsonContext jsonContext) {
+        this.jsonContext = jsonContext;
+        builder = new JsonArrayBuilderImpl(patch, jsonContext);
     }
 
     /**
      * Creates JsonPatchBuilderImpl with empty JSON Patch
      */
-    public JsonPatchBuilderImpl() {
-        builder = Json.createArrayBuilder();
+    public JsonPatchBuilderImpl(JsonContext jsonContext) {
+        this.jsonContext = jsonContext;
+        builder = new JsonArrayBuilderImpl(jsonContext);
     }
 
     /**
@@ -88,7 +90,7 @@ public final class JsonPatchBuilderImpl implements JsonPatchBuilder {
      */
     @Override
     public JsonPatchBuilder add(String path, JsonValue value) {
-        builder.add(Json.createObjectBuilder()
+        builder.add(new JsonObjectBuilderImpl(jsonContext)
                            .add("op", Operation.ADD.operationName())
                            .add("path", path)
                            .add("value", value)
@@ -104,7 +106,7 @@ public final class JsonPatchBuilderImpl implements JsonPatchBuilder {
      */
     @Override
     public JsonPatchBuilder add(String path, String value) {
-        builder.add(Json.createObjectBuilder()
+        builder.add(new JsonObjectBuilderImpl(jsonContext)
                            .add("op", Operation.ADD.operationName())
                            .add("path", path)
                            .add("value", value)
@@ -120,7 +122,7 @@ public final class JsonPatchBuilderImpl implements JsonPatchBuilder {
      */
     @Override
     public JsonPatchBuilder add(String path, int value) {
-        builder.add(Json.createObjectBuilder()
+        builder.add(new JsonObjectBuilderImpl(jsonContext)
                            .add("op", Operation.ADD.operationName())
                            .add("path", path)
                            .add("value", value)
@@ -136,7 +138,7 @@ public final class JsonPatchBuilderImpl implements JsonPatchBuilder {
      */
     @Override
     public JsonPatchBuilder add(String path, boolean value) {
-        builder.add(Json.createObjectBuilder()
+        builder.add(new JsonObjectBuilderImpl(jsonContext)
                            .add("op", Operation.ADD.operationName())
                            .add("path", path)
                            .add("value", value)
@@ -151,7 +153,7 @@ public final class JsonPatchBuilderImpl implements JsonPatchBuilder {
      */
     @Override
     public JsonPatchBuilder remove(String path) {
-        builder.add(Json.createObjectBuilder()
+        builder.add(new JsonObjectBuilderImpl(jsonContext)
                            .add("op", Operation.REMOVE.operationName())
                            .add("path", path)
                     );
@@ -166,7 +168,7 @@ public final class JsonPatchBuilderImpl implements JsonPatchBuilder {
      */
     @Override
     public JsonPatchBuilder replace(String path, JsonValue value) {
-        builder.add(Json.createObjectBuilder()
+        builder.add(new JsonObjectBuilderImpl(jsonContext)
                            .add("op", Operation.REPLACE.operationName())
                            .add("path", path)
                            .add("value", value)
@@ -182,7 +184,7 @@ public final class JsonPatchBuilderImpl implements JsonPatchBuilder {
      */
     @Override
     public JsonPatchBuilder replace(String path, String value) {
-        builder.add(Json.createObjectBuilder()
+        builder.add(new JsonObjectBuilderImpl(jsonContext)
                            .add("op", Operation.REPLACE.operationName())
                            .add("path", path)
                            .add("value", value)
@@ -198,7 +200,7 @@ public final class JsonPatchBuilderImpl implements JsonPatchBuilder {
      */
     @Override
     public JsonPatchBuilder replace(String path, int value) {
-        builder.add(Json.createObjectBuilder()
+        builder.add(new JsonObjectBuilderImpl(jsonContext)
                            .add("op", Operation.REPLACE.operationName())
                            .add("path", path)
                            .add("value", value)
@@ -214,7 +216,7 @@ public final class JsonPatchBuilderImpl implements JsonPatchBuilder {
      */
     @Override
     public JsonPatchBuilder replace(String path, boolean value) {
-        builder.add(Json.createObjectBuilder()
+        builder.add(new JsonObjectBuilderImpl(jsonContext)
                            .add("op", Operation.REPLACE.operationName())
                            .add("path", path)
                            .add("value", value)
@@ -230,7 +232,7 @@ public final class JsonPatchBuilderImpl implements JsonPatchBuilder {
      */
     @Override
     public JsonPatchBuilder move(String path, String from) {
-        builder.add(Json.createObjectBuilder()
+        builder.add(new JsonObjectBuilderImpl(jsonContext)
                            .add("op", Operation.MOVE.operationName())
                            .add("path", path)
                            .add("from", from)
@@ -246,7 +248,7 @@ public final class JsonPatchBuilderImpl implements JsonPatchBuilder {
      */
     @Override
     public JsonPatchBuilder copy(String path, String from) {
-        builder.add(Json.createObjectBuilder()
+        builder.add(new JsonObjectBuilderImpl(jsonContext)
                            .add("op", Operation.COPY.operationName())
                            .add("path", path)
                            .add("from", from)
@@ -262,7 +264,7 @@ public final class JsonPatchBuilderImpl implements JsonPatchBuilder {
      */
     @Override
     public JsonPatchBuilder test(String path, JsonValue value) {
-        builder.add(Json.createObjectBuilder()
+        builder.add(new JsonObjectBuilderImpl(jsonContext)
                            .add("op", Operation.TEST.operationName())
                            .add("path", path)
                            .add("value", value)
@@ -278,7 +280,7 @@ public final class JsonPatchBuilderImpl implements JsonPatchBuilder {
      */
     @Override
     public JsonPatchBuilder test(String path, String value) {
-        builder.add(Json.createObjectBuilder()
+        builder.add(new JsonObjectBuilderImpl(jsonContext)
                            .add("op", Operation.TEST.operationName())
                            .add("path", path)
                            .add("value", value)
@@ -294,7 +296,7 @@ public final class JsonPatchBuilderImpl implements JsonPatchBuilder {
      */
     @Override
     public JsonPatchBuilder test(String path, int value) {
-        builder.add(Json.createObjectBuilder()
+        builder.add(new JsonObjectBuilderImpl(jsonContext)
                            .add("op", Operation.TEST.operationName())
                            .add("path", path)
                            .add("value", value)
@@ -310,7 +312,7 @@ public final class JsonPatchBuilderImpl implements JsonPatchBuilder {
      */
     @Override
     public JsonPatchBuilder test(String path, boolean value) {
-        builder.add(Json.createObjectBuilder()
+        builder.add(new JsonObjectBuilderImpl(jsonContext)
                            .add("op", Operation.TEST.operationName())
                            .add("path", path)
                            .add("value", value)
@@ -332,7 +334,8 @@ public final class JsonPatchBuilderImpl implements JsonPatchBuilder {
      */
     @Override
     public JsonPatch build() {
-        return new JsonPatchImpl(buildAsJsonArray());
+        return new JsonPatchImpl(buildAsJsonArray(), jsonContext);
     }
+
 }
 

--- a/impl/src/main/java/org/glassfish/json/JsonPointerImpl.java
+++ b/impl/src/main/java/org/glassfish/json/JsonPointerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -52,6 +52,7 @@ public final class JsonPointerImpl implements JsonPointer, Serializable {
     private static final long serialVersionUID = -8123110179640843141L;
     private final String[] tokens;
     private final String jsonPointer;
+    private final JsonContext jsonContext;
 
     /**
      * Constructs and initializes a JsonPointerImpl.
@@ -59,8 +60,9 @@ public final class JsonPointerImpl implements JsonPointer, Serializable {
      * @throws NullPointerException if {@code jsonPointer} is {@code null}
      * @throws JsonException if {@code jsonPointer} is not a valid JSON Pointer
      */
-    public JsonPointerImpl(String jsonPointer) {
+    public JsonPointerImpl(String jsonPointer, JsonContext jsonContext) {
         this.jsonPointer = jsonPointer;
+        this.jsonContext = jsonContext;
         tokens = jsonPointer.split("/", -1);  // keep the trailing blanks
         if (! "".equals(tokens[0])) {
             throw new JsonException(JsonMessages.POINTER_FORMAT_INVALID());
@@ -235,7 +237,7 @@ public final class JsonPointerImpl implements JsonPointer, Serializable {
             switch (value.getValueType()) {
                 case OBJECT:
                     JsonObject object = (JsonObject) value;
-                    references[s-i-1] = NodeReference.of(object, tokens[i]);
+                    references[s-i-1] = NodeReference.of(object, tokens[i], jsonContext);
                     if (i < s-1) {
                         value = object.get(tokens[i]);
                         if (value == null) {
@@ -247,7 +249,7 @@ public final class JsonPointerImpl implements JsonPointer, Serializable {
                 case ARRAY:
                     int index = getIndex(tokens[i]);
                     JsonArray array = (JsonArray) value;
-                    references[s-i-1] = NodeReference.of(array, index);
+                    references[s-i-1] = NodeReference.of(array, index, jsonContext);
                     if (i < s-1 && index != -1) {
                         if (index >= array.size()) {
                             throw new JsonException(JsonMessages.NODEREF_ARRAY_INDEX_ERR(index, array.size()));

--- a/impl/src/main/java/org/glassfish/json/JsonPrettyGeneratorImpl.java
+++ b/impl/src/main/java/org/glassfish/json/JsonPrettyGeneratorImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,8 +16,6 @@
 
 package org.glassfish.json;
 
-import org.glassfish.json.api.BufferPool;
-
 import javax.json.stream.JsonGenerator;
 import java.io.OutputStream;
 import java.io.Writer;
@@ -27,19 +25,20 @@ import java.nio.charset.Charset;
  * @author Jitendra Kotamraju
  */
 public class JsonPrettyGeneratorImpl extends JsonGeneratorImpl {
+
     private int indentLevel;
     private static final String INDENT = "    ";
 
-    public JsonPrettyGeneratorImpl(Writer writer, BufferPool bufferPool) {
-        super(writer, bufferPool);
+    public JsonPrettyGeneratorImpl(Writer writer, JsonContext jsonContext) {
+        super(writer, jsonContext);
     }
 
-    public JsonPrettyGeneratorImpl(OutputStream out, BufferPool bufferPool) {
-        super(out, bufferPool);
+    public JsonPrettyGeneratorImpl(OutputStream out, JsonContext jsonContext) {
+        super(out, jsonContext);
     }
 
-    public JsonPrettyGeneratorImpl(OutputStream out, Charset encoding, BufferPool bufferPool) {
-        super(out, encoding, bufferPool);
+    public JsonPrettyGeneratorImpl(OutputStream out, Charset encoding, JsonContext jsonContext) {
+        super(out, encoding, jsonContext);
     }
 
     @Override

--- a/impl/src/main/java/org/glassfish/json/JsonProviderImpl.java
+++ b/impl/src/main/java/org/glassfish/json/JsonProviderImpl.java
@@ -65,7 +65,9 @@ public class JsonProviderImpl extends JsonProvider {
 
     @Override
     public JsonParserFactory createParserFactory(Map<String, ?> config) {
-        return new JsonParserFactoryImpl(new JsonContext(config, bufferPool));
+        return config == null
+                ? new JsonParserFactoryImpl(emptyContext)
+                : new JsonParserFactoryImpl(new JsonContext(config, bufferPool, JsonContext.PROPERTY_BUFFER_POOL));
     }
 
     @Override

--- a/impl/src/main/java/org/glassfish/json/JsonProviderImpl.java
+++ b/impl/src/main/java/org/glassfish/json/JsonProviderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -29,8 +29,6 @@ import java.io.OutputStream;
 import java.io.Reader;
 import java.io.Writer;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -43,185 +41,145 @@ import java.math.BigInteger;
 public class JsonProviderImpl extends JsonProvider {
 
     private final BufferPool bufferPool = new BufferPoolImpl();
+    private final JsonContext emptyContext = new JsonContext(null, bufferPool);
 
     @Override
     public JsonGenerator createGenerator(Writer writer) {
-        return new JsonGeneratorImpl(writer, bufferPool);
+        return new JsonGeneratorImpl(writer, emptyContext);
     }
 
     @Override
     public JsonGenerator createGenerator(OutputStream out) {
-        return new JsonGeneratorImpl(out, bufferPool);
+        return new JsonGeneratorImpl(out, emptyContext);
     }
 
     @Override
     public JsonParser createParser(Reader reader) {
-        return new JsonParserImpl(reader, bufferPool);
+        return new JsonParserImpl(reader, emptyContext);
     }
 
     @Override
     public JsonParser createParser(InputStream in) {
-        return new JsonParserImpl(in, bufferPool);
+        return new JsonParserImpl(in, emptyContext);
     }
 
     @Override
     public JsonParserFactory createParserFactory(Map<String, ?> config) {
-        BufferPool pool = null;
-        if (config != null && config.containsKey(BufferPool.class.getName())) {
-            pool = (BufferPool)config.get(BufferPool.class.getName());
-        }
-        if (pool == null) {
-            pool = bufferPool;
-        }
-        return new JsonParserFactoryImpl(pool);
+        return new JsonParserFactoryImpl(new JsonContext(config, bufferPool));
     }
 
     @Override
     public JsonGeneratorFactory createGeneratorFactory(Map<String, ?> config) {
-        Map<String, Object> providerConfig;
-        boolean prettyPrinting;
-        BufferPool pool;
-        if (config == null) {
-            providerConfig = Collections.emptyMap();
-            prettyPrinting = false;
-            pool = bufferPool;
-        } else {
-            providerConfig = new HashMap<>();
-            if (prettyPrinting=JsonProviderImpl.isPrettyPrintingEnabled(config)) {
-                providerConfig.put(JsonGenerator.PRETTY_PRINTING, true);
-            }
-            pool = (BufferPool)config.get(BufferPool.class.getName());
-            if (pool != null) {
-                providerConfig.put(BufferPool.class.getName(), pool);
-            } else {
-                pool = bufferPool;
-            }
-            providerConfig = Collections.unmodifiableMap(providerConfig);
-        }
-
-        return new JsonGeneratorFactoryImpl(providerConfig, prettyPrinting, pool);
+        return config == null
+                ? new JsonGeneratorFactoryImpl(emptyContext)
+                : new JsonGeneratorFactoryImpl(
+                        new JsonContext(config, bufferPool,
+                                        JsonGenerator.PRETTY_PRINTING,
+                                        JsonContext.PROPERTY_BUFFER_POOL));
     }
 
     @Override
     public JsonReader createReader(Reader reader) {
-        return new JsonReaderImpl(reader, bufferPool);
+        return new JsonReaderImpl(reader, emptyContext);
     }
 
     @Override
     public JsonReader createReader(InputStream in) {
-        return new JsonReaderImpl(in, bufferPool);
+        return new JsonReaderImpl(in, emptyContext);
     }
 
     @Override
     public JsonWriter createWriter(Writer writer) {
-        return new JsonWriterImpl(writer, bufferPool);
+        return new JsonWriterImpl(writer, emptyContext);
     }
 
     @Override
     public JsonWriter createWriter(OutputStream out) {
-        return new JsonWriterImpl(out, bufferPool);
+        return new JsonWriterImpl(out, emptyContext);
     }
 
     @Override
     public JsonWriterFactory createWriterFactory(Map<String, ?> config) {
-        Map<String, Object> providerConfig;
-        boolean prettyPrinting;
-        BufferPool pool;
-        if (config == null) {
-            providerConfig = Collections.emptyMap();
-            prettyPrinting = false;
-            pool = bufferPool;
-        } else {
-            providerConfig = new HashMap<>();
-            if (prettyPrinting=JsonProviderImpl.isPrettyPrintingEnabled(config)) {
-                providerConfig.put(JsonGenerator.PRETTY_PRINTING, true);
-            }
-            pool = (BufferPool)config.get(BufferPool.class.getName());
-            if (pool != null) {
-                providerConfig.put(BufferPool.class.getName(), pool);
-            } else {
-                pool = bufferPool;
-            }
-            providerConfig = Collections.unmodifiableMap(providerConfig);
-        }
-        return new JsonWriterFactoryImpl(providerConfig, prettyPrinting, pool);
+        return config == null
+                ? new JsonWriterFactoryImpl(emptyContext)
+                : new JsonWriterFactoryImpl(
+                        new JsonContext(config, bufferPool,
+                                        JsonGenerator.PRETTY_PRINTING,
+                                        JsonContext.PROPERTY_BUFFER_POOL));
     }
 
     @Override
     public JsonReaderFactory createReaderFactory(Map<String, ?> config) {
-        BufferPool pool = null;
-        if (config != null && config.containsKey(BufferPool.class.getName())) {
-            pool = (BufferPool)config.get(BufferPool.class.getName());
-        }
-        if (pool == null) {
-            pool = bufferPool;
-        }
-        return new JsonReaderFactoryImpl(pool);
+        return config == null
+                ? new JsonReaderFactoryImpl(emptyContext)
+                : new JsonReaderFactoryImpl(
+                        new JsonContext(config, bufferPool,
+                                        JsonContext.PROPERTY_BUFFER_POOL));
     }
 
     @Override
     public JsonObjectBuilder createObjectBuilder() {
-        return new JsonObjectBuilderImpl(bufferPool);
+        return new JsonObjectBuilderImpl(emptyContext);
     }
 
     @Override
     public JsonObjectBuilder createObjectBuilder(JsonObject object) {
-        return new JsonObjectBuilderImpl(object, bufferPool);
+        return new JsonObjectBuilderImpl(object, emptyContext);
     }
 
     @Override
     public JsonObjectBuilder createObjectBuilder(Map<String, Object> map) {
-        return new JsonObjectBuilderImpl(map, bufferPool);
+        return new JsonObjectBuilderImpl(map, emptyContext);
     }
 
     @Override
     public JsonArrayBuilder createArrayBuilder() {
-        return new JsonArrayBuilderImpl(bufferPool);
+        return new JsonArrayBuilderImpl(emptyContext);
     }
 
     @Override
     public JsonArrayBuilder createArrayBuilder(JsonArray array) {
-        return new JsonArrayBuilderImpl(array, bufferPool);
+        return new JsonArrayBuilderImpl(array, emptyContext);
     }
 
     @Override
     public JsonArrayBuilder createArrayBuilder(Collection<?> collection) {
-        return new JsonArrayBuilderImpl(collection, bufferPool);
+        return new JsonArrayBuilderImpl(collection, emptyContext);
     }
 
     @Override
     public JsonPointer createPointer(String jsonPointer) {
-        return new JsonPointerImpl(jsonPointer);
+        return new JsonPointerImpl(jsonPointer, emptyContext);
     }
 
     @Override
     public JsonPatchBuilder createPatchBuilder() {
-        return new JsonPatchBuilderImpl();
+        return new JsonPatchBuilderImpl(emptyContext);
     }
 
     @Override
     public JsonPatchBuilder createPatchBuilder(JsonArray array) {
-        return new JsonPatchBuilderImpl(array);
+        return new JsonPatchBuilderImpl(array, emptyContext);
     }
 
     @Override
     public JsonPatch createPatch(JsonArray array) {
-        return new JsonPatchImpl(array);
+        return new JsonPatchImpl(array, emptyContext);
     }
 
     @Override
     public JsonPatch createDiff(JsonStructure source, JsonStructure target) {
-        return new JsonPatchImpl(JsonPatchImpl.diff(source, target));
+        return new JsonPatchImpl(JsonPatchImpl.diff(source, target, emptyContext), emptyContext);
     }
 
     @Override
     public JsonMergePatch createMergePatch(JsonValue patch) {
-        return new JsonMergePatchImpl(patch);
+        return new JsonMergePatchImpl(patch, emptyContext);
     }
 
     @Override
     public JsonMergePatch createMergeDiff(JsonValue source, JsonValue target) {
-        return new JsonMergePatchImpl(JsonMergePatchImpl.diff(source, target));
+        return new JsonMergePatchImpl(JsonMergePatchImpl.diff(source, target, emptyContext), emptyContext);
     }
 
     @Override
@@ -231,42 +189,36 @@ public class JsonProviderImpl extends JsonProvider {
 
     @Override
     public JsonNumber createValue(int value) {
-        return JsonNumberImpl.getJsonNumber(value);
+        return JsonNumberImpl.getJsonNumber(value, emptyContext.bigIntegerScaleLimit());
     }
 
     @Override
     public JsonNumber createValue(long value) {
-        return JsonNumberImpl.getJsonNumber(value);
+        return JsonNumberImpl.getJsonNumber(value, emptyContext.bigIntegerScaleLimit());
     }
 
     @Override
     public JsonNumber createValue(double value) {
-        return JsonNumberImpl.getJsonNumber(value);
+        return JsonNumberImpl.getJsonNumber(value, emptyContext.bigIntegerScaleLimit());
     }
 
     @Override
     public JsonNumber createValue(BigInteger value) {
-        return JsonNumberImpl.getJsonNumber(value);
+        return JsonNumberImpl.getJsonNumber(value, emptyContext.bigIntegerScaleLimit());
     }
 
     @Override
     public JsonNumber createValue(BigDecimal value) {
-        return JsonNumberImpl.getJsonNumber(value);
+        return JsonNumberImpl.getJsonNumber(value, emptyContext.bigIntegerScaleLimit());
     }
 
     @Override
-    public JsonBuilderFactory createBuilderFactory(Map<String,?> config) {
-        BufferPool pool = null ;
-        if (config != null && config.containsKey(BufferPool.class.getName())) {
-            pool = (BufferPool)config.get(BufferPool.class.getName());
-        }
-        if (pool == null) {
-            pool = bufferPool;
-        }
-        return new JsonBuilderFactoryImpl(pool);
+    public JsonBuilderFactory createBuilderFactory(Map<String, ?> config) {
+        return config == null
+                ? new JsonBuilderFactoryImpl(emptyContext)
+                : new JsonBuilderFactoryImpl(
+                        new JsonContext(config, bufferPool,
+                                        JsonContext.PROPERTY_BUFFER_POOL));
     }
 
-    static boolean isPrettyPrintingEnabled(Map<String, ?> config) {
-        return config.containsKey(JsonGenerator.PRETTY_PRINTING);
-    }
 }

--- a/impl/src/main/java/org/glassfish/json/JsonReaderFactoryImpl.java
+++ b/impl/src/main/java/org/glassfish/json/JsonReaderFactoryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,44 +16,41 @@
 
 package org.glassfish.json;
 
-import org.glassfish.json.api.BufferPool;
-
 import javax.json.JsonReader;
 import javax.json.JsonReaderFactory;
 import java.io.InputStream;
 import java.io.Reader;
 import java.nio.charset.Charset;
-import java.util.Collections;
 import java.util.Map;
 
 /**
  * @author Jitendra Kotamraju
  */
 class JsonReaderFactoryImpl implements JsonReaderFactory {
-    private final Map<String, ?> config = Collections.emptyMap();
-    private final BufferPool bufferPool;
 
-    JsonReaderFactoryImpl(BufferPool bufferPool) {
-        this.bufferPool = bufferPool;
+    private final JsonContext jsonContext;
+
+    JsonReaderFactoryImpl(JsonContext jsonContext) {
+        this.jsonContext = jsonContext;
     }
 
     @Override
     public JsonReader createReader(Reader reader) {
-        return new JsonReaderImpl(reader, bufferPool);
+        return new JsonReaderImpl(reader, jsonContext);
     }
 
     @Override
     public JsonReader createReader(InputStream in) {
-        return new JsonReaderImpl(in, bufferPool);
+        return new JsonReaderImpl(in, jsonContext);
     }
 
     @Override
     public JsonReader createReader(InputStream in, Charset charset) {
-        return new JsonReaderImpl(in, charset, bufferPool);
+        return new JsonReaderImpl(in, charset, jsonContext);
     }
 
     @Override
     public Map<String, ?> getConfigInUse() {
-        return config;
+        return jsonContext.config();
     }
 }

--- a/impl/src/main/java/org/glassfish/json/JsonReaderImpl.java
+++ b/impl/src/main/java/org/glassfish/json/JsonReaderImpl.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2013, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -15,8 +16,6 @@
  */
 
 package org.glassfish.json;
-
-import org.glassfish.json.api.BufferPool;
 
 import java.io.InputStream;
 import java.io.Reader;
@@ -36,23 +35,20 @@ import javax.json.stream.JsonParsingException;
  * @author Jitendra Kotamraju
  */
 class JsonReaderImpl implements JsonReader {
+
     private final JsonParserImpl parser;
     private boolean readDone;
-    private final BufferPool bufferPool;
-
-    JsonReaderImpl(Reader reader, BufferPool bufferPool) {
-        parser = new JsonParserImpl(reader, bufferPool);
-        this.bufferPool = bufferPool;
+    
+    JsonReaderImpl(Reader reader, JsonContext jsonContext) {
+        parser = new JsonParserImpl(reader, jsonContext);
     }
 
-    JsonReaderImpl(InputStream in, BufferPool bufferPool) {
-        parser = new JsonParserImpl(in, bufferPool);
-        this.bufferPool = bufferPool;
+    JsonReaderImpl(InputStream in, JsonContext jsonContext) {
+        parser = new JsonParserImpl(in, jsonContext);
     }
 
-    JsonReaderImpl(InputStream in, Charset charset, BufferPool bufferPool) {
-        parser = new JsonParserImpl(in, charset, bufferPool);
-        this.bufferPool = bufferPool;
+    JsonReaderImpl(InputStream in, Charset charset, JsonContext jsonContext) {
+        parser = new JsonParserImpl(in, charset, jsonContext);
     }
 
     @Override

--- a/impl/src/main/java/org/glassfish/json/JsonTokenizer.java
+++ b/impl/src/main/java/org/glassfish/json/JsonTokenizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -119,9 +119,9 @@ final class JsonTokenizer implements Closeable {
         }
     }
 
-    JsonTokenizer(Reader reader, BufferPool bufferPool) {
+    JsonTokenizer(Reader reader, JsonContext jsonContext) {
         this.reader = reader;
-        this.bufferPool = bufferPool;
+        this.bufferPool = jsonContext.bufferPool();
         buf = bufferPool.take();
     }
 

--- a/impl/src/main/java/org/glassfish/json/JsonWriterFactoryImpl.java
+++ b/impl/src/main/java/org/glassfish/json/JsonWriterFactoryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,8 +16,6 @@
 
 package org.glassfish.json;
 
-import org.glassfish.json.api.BufferPool;
-
 import javax.json.JsonWriter;
 import javax.json.JsonWriterFactory;
 import java.io.OutputStream;
@@ -29,34 +27,31 @@ import java.util.Map;
  * @author Jitendra Kotamraju
  */
 class JsonWriterFactoryImpl implements JsonWriterFactory {
-    private final Map<String, ?> config;        // unmodifiable map
-    private final boolean prettyPrinting;
-    private final BufferPool bufferPool;
 
-    JsonWriterFactoryImpl(Map<String, ?> config, boolean prettyPrinting,
-            BufferPool bufferPool) {
-        this.config = config;
-        this.prettyPrinting = prettyPrinting;
-        this.bufferPool = bufferPool;
+    private final JsonContext jsonContext;
+
+    JsonWriterFactoryImpl(JsonContext jsonContext) {
+        this.jsonContext = jsonContext;
     }
 
     @Override
     public JsonWriter createWriter(Writer writer) {
-        return new JsonWriterImpl(writer, prettyPrinting, bufferPool);
+        return new JsonWriterImpl(writer, jsonContext);
     }
 
     @Override
     public JsonWriter createWriter(OutputStream out) {
-        return new JsonWriterImpl(out, prettyPrinting, bufferPool);
+        return new JsonWriterImpl(out, jsonContext);
     }
 
     @Override
     public JsonWriter createWriter(OutputStream out, Charset charset) {
-        return new JsonWriterImpl(out, charset, prettyPrinting, bufferPool);
+        return new JsonWriterImpl(out, charset, jsonContext);
     }
 
     @Override
     public Map<String, ?> getConfigInUse() {
-        return config;
+        return jsonContext.config();
     }
+
 }

--- a/impl/src/main/java/org/glassfish/json/JsonWriterImpl.java
+++ b/impl/src/main/java/org/glassfish/json/JsonWriterImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -15,8 +15,6 @@
  */
 
 package org.glassfish.json;
-
-import org.glassfish.json.api.BufferPool;
 
 import javax.json.*;
 import java.io.FilterOutputStream;
@@ -38,33 +36,24 @@ class JsonWriterImpl implements JsonWriter {
     private boolean writeDone;
     private final NoFlushOutputStream os;
 
-    JsonWriterImpl(Writer writer, BufferPool bufferPool) {
-        this(writer, false, bufferPool);
+    JsonWriterImpl(Writer writer, JsonContext jsonContext) {
+        this.generator = jsonContext.prettyPrinting()
+                ? new JsonPrettyGeneratorImpl(writer, jsonContext)
+                : new JsonGeneratorImpl(writer, jsonContext);
+        this.os = null;
     }
 
-    JsonWriterImpl(Writer writer, boolean prettyPrinting, BufferPool bufferPool) {
-        generator = prettyPrinting
-                ? new JsonPrettyGeneratorImpl(writer, bufferPool)
-                : new JsonGeneratorImpl(writer, bufferPool);
-        os = null;
+    JsonWriterImpl(OutputStream out, JsonContext jsonContext) {
+        this(out, StandardCharsets.UTF_8, jsonContext);
     }
 
-    JsonWriterImpl(OutputStream out, BufferPool bufferPool) {
-        this(out, StandardCharsets.UTF_8, false, bufferPool);
-    }
-
-    JsonWriterImpl(OutputStream out, boolean prettyPrinting, BufferPool bufferPool) {
-        this(out, StandardCharsets.UTF_8, prettyPrinting, bufferPool);
-    }
-
-    JsonWriterImpl(OutputStream out, Charset charset,
-                   boolean prettyPrinting, BufferPool bufferPool) {
+    JsonWriterImpl(OutputStream out, Charset charset, JsonContext jsonContext) {
         // Decorating the given stream, so that buffered contents can be
         // written without actually flushing the stream.
         this.os = new NoFlushOutputStream(out);
-        generator = prettyPrinting
-                ? new JsonPrettyGeneratorImpl(os, charset, bufferPool)
-                : new JsonGeneratorImpl(os, charset, bufferPool);
+        this.generator = jsonContext.prettyPrinting()
+                ? new JsonPrettyGeneratorImpl(os, charset, jsonContext)
+                : new JsonGeneratorImpl(os, charset, jsonContext);
     }
 
     @Override

--- a/impl/src/main/java/org/glassfish/json/MapUtil.java
+++ b/impl/src/main/java/org/glassfish/json/MapUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -15,8 +15,6 @@
  */
 
 package org.glassfish.json;
-
-import org.glassfish.json.api.BufferPool;
 
 import javax.json.JsonArrayBuilder;
 import javax.json.JsonObjectBuilder;
@@ -37,52 +35,38 @@ public final class MapUtil {
         super();
     }
 
-    static JsonValue handle(Object value, BufferPool bufferPool) {
-
+    static JsonValue handle(Object value, JsonContext jsonContext) {
         if (value == null) {
             return JsonValue.NULL;
-        }
-
-        if (value instanceof BigDecimal) {
-            return JsonNumberImpl.getJsonNumber((BigDecimal) value);
-        } else {
-            if (value instanceof BigInteger) {
-                return JsonNumberImpl.getJsonNumber((BigInteger) value);
-            } else {
-                if ( value instanceof Boolean) {
-                    Boolean b = (Boolean) value;
-                    return b ? JsonValue.TRUE : JsonValue.FALSE;
-                } else {
-                    if (value instanceof Double) {
-                        return JsonNumberImpl.getJsonNumber((Double) value);
-                    } else {
-                        if (value instanceof Integer) {
-                            return JsonNumberImpl.getJsonNumber((Integer) value);
-                        } else {
-                            if (value instanceof Long) {
-                                return JsonNumberImpl.getJsonNumber((Long) value);
-                            } else {
-                                if (value instanceof String) {
-                                    return new JsonStringImpl((String) value);
-                                } else {
-                                    if (value instanceof Collection) {
-                                        @SuppressWarnings("unchecked")
-                                        Collection<?> collection = (Collection<?>) value;
-                                        JsonArrayBuilder jsonArrayBuilder = new JsonArrayBuilderImpl(collection, bufferPool);
-                                        return jsonArrayBuilder.build();
-                                    } else {
-                                        if (value instanceof Map) {
-                                            @SuppressWarnings("unchecked")
-                                            JsonObjectBuilder object = new JsonObjectBuilderImpl((Map<String, Object>) value, bufferPool);
-                                            return object.build();
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+        } else if (value instanceof JsonValue) {
+            return (JsonValue) value;
+        } else if (value instanceof JsonArrayBuilder) {
+            return ((JsonArrayBuilder) value).build();
+        } else if (value instanceof JsonObjectBuilder) {
+            return ((JsonObjectBuilder) value).build();
+        } else if (value instanceof BigDecimal) {
+            return JsonNumberImpl.getJsonNumber((BigDecimal) value, jsonContext.bigIntegerScaleLimit());
+        } else if (value instanceof BigInteger) {
+            return JsonNumberImpl.getJsonNumber((BigInteger) value, jsonContext.bigIntegerScaleLimit());
+        } else if (value instanceof Boolean) {
+            Boolean b = (Boolean) value;
+            return b ? JsonValue.TRUE : JsonValue.FALSE;
+        } else if (value instanceof Double) {
+            return JsonNumberImpl.getJsonNumber((Double) value, jsonContext.bigIntegerScaleLimit());
+        } else if (value instanceof Integer) {
+            return JsonNumberImpl.getJsonNumber((Integer) value, jsonContext.bigIntegerScaleLimit());
+        } else if (value instanceof Long) {
+            return JsonNumberImpl.getJsonNumber((Long) value, jsonContext.bigIntegerScaleLimit());
+        } else if (value instanceof String) {
+            return new JsonStringImpl((String) value);
+        } else if (value instanceof Collection) {
+            Collection<?> collection = (Collection<?>) value;
+            JsonArrayBuilder jsonArrayBuilder = new JsonArrayBuilderImpl(collection, jsonContext);
+            return jsonArrayBuilder.build();
+        } else if (value instanceof Map) {
+            @SuppressWarnings("unchecked")
+            JsonObjectBuilder object = new JsonObjectBuilderImpl((Map<String, Object>) value, jsonContext);
+            return object.build();
         }
 
         throw new IllegalArgumentException(String.format("Type %s is not supported.", value.getClass()));

--- a/impl/src/main/java/org/glassfish/json/NodeReference.java
+++ b/impl/src/main/java/org/glassfish/json/NodeReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -106,7 +106,7 @@ abstract class NodeReference {
      * @param structure the {@code JsonStructure} referenced
      * @return the {@code NodeReference}
      */
-    public static NodeReference of(JsonStructure structure) {
+    static NodeReference of(JsonStructure structure) {
         return new RootReference(structure);
     }
 
@@ -118,8 +118,8 @@ abstract class NodeReference {
      * @param name the name of the name/pair
      * @return the {@code NodeReference}
      */
-    public static NodeReference of(JsonObject object, String name) {
-        return new ObjectReference(object, name);
+    static NodeReference of(JsonObject object, String name, JsonContext jsonContext) {
+        return new ObjectReference(object, name, jsonContext);
     }
 
     /**
@@ -130,8 +130,8 @@ abstract class NodeReference {
      * @param index the index of the member value in the JSON array
      * @return the {@code NodeReference}
      */
-    public static NodeReference of(JsonArray array, int index) {
-        return new ArrayReference(array, index);
+    static NodeReference of(JsonArray array, int index, JsonContext jsonContext) {
+        return new ArrayReference(array, index, jsonContext);
     }
 
     static class RootReference extends NodeReference {
@@ -180,10 +180,12 @@ abstract class NodeReference {
 
         private final JsonObject object;
         private final String key;
+        private final JsonContext jsonContext;
 
-        ObjectReference(JsonObject object, String key) {
+        ObjectReference(JsonObject object, String key, JsonContext jsonContext) {
             this.object = object;
             this.key = key;
+            this.jsonContext = jsonContext;
         }
 
         @Override
@@ -201,7 +203,7 @@ abstract class NodeReference {
 
         @Override
         public JsonObject add(JsonValue value) {
-            return Json.createObjectBuilder(object).add(key, value).build();
+            return new JsonObjectBuilderImpl(object, jsonContext).add(key, value).build();
         }
 
         @Override
@@ -209,7 +211,7 @@ abstract class NodeReference {
             if (!contains()) {
                 throw new JsonException(JsonMessages.NODEREF_OBJECT_MISSING(key));
             }
-            return Json.createObjectBuilder(object).remove(key).build();
+            return new JsonObjectBuilderImpl(object, jsonContext).remove(key).build();
         }
 
         @Override
@@ -225,10 +227,12 @@ abstract class NodeReference {
 
         private final JsonArray array;
         private final int index; // -1 means "-" in JSON Pointer
+        private final JsonContext jsonContext;
 
-        ArrayReference(JsonArray array, int index) {
+        ArrayReference(JsonArray array, int index, JsonContext jsonContext) {
             this.array = array;
             this.index = index;
+            this.jsonContext = jsonContext;
         }
 
         @Override
@@ -248,7 +252,7 @@ abstract class NodeReference {
         public JsonArray add(JsonValue value) {
             //TODO should we check for arrayoutofbounds?
             // The spec seems to say index = array.size() is allowed. This is handled as append
-            JsonArrayBuilder builder = Json.createArrayBuilder(this.array);
+            JsonArrayBuilder builder = new JsonArrayBuilderImpl(this.array, jsonContext);
             if (index == -1 || index == array.size()) {
                 builder.add(value);
             } else {
@@ -266,7 +270,7 @@ abstract class NodeReference {
             if (!contains()) {
                 throw new JsonException(JsonMessages.NODEREF_ARRAY_INDEX_ERR(index, array.size()));
             }
-            JsonArrayBuilder builder = Json.createArrayBuilder(this.array);
+            JsonArrayBuilder builder = new JsonArrayBuilderImpl(this.array, jsonContext);
             return builder.remove(index).build();
         }
 
@@ -275,7 +279,7 @@ abstract class NodeReference {
             if (!contains()) {
                 throw new JsonException(JsonMessages.NODEREF_ARRAY_INDEX_ERR(index, array.size()));
             }
-            JsonArrayBuilder builder = Json.createArrayBuilder(this.array);
+            JsonArrayBuilder builder = new JsonArrayBuilderImpl(this.array, jsonContext);
             return builder.set(index, value).build();
         }
     }

--- a/impl/src/main/java/org/glassfish/json/api/JsonConfig.java
+++ b/impl/src/main/java/org/glassfish/json/api/JsonConfig.java
@@ -25,6 +25,13 @@ public interface JsonConfig {
      * and {@link javax.json.JsonNumber#bigIntegerValueExact()} implemented methods.
      * Default value is set to {@code 100000}.
      */
-    String MAX_BIGINT_SCALE = "org.eclipse.parsson.maxBigIntegerScale";
+    String MAX_BIGINTEGER_SCALE = "org.eclipse.parsson.maxBigIntegerScale";
+
+    /**
+     * Configuration property to limit maximum value of BigDecimal length when being parsed.
+     * This property limits maximum number of characters of BigDecimal source being parsed.
+     * Default value is set to {@code 1100}.
+     */
+    String MAX_BIGDECIMAL_LEN = "org.eclipse.parsson.maxBigDecimalLength";
 
 }

--- a/impl/src/main/java/org/glassfish/json/api/JsonConfig.java
+++ b/impl/src/main/java/org/glassfish/json/api/JsonConfig.java
@@ -19,8 +19,8 @@ package org.glassfish.json.api;
 public interface JsonConfig {
 
     /**
-     * Configuration property to limit maximum value of BigInteger scale value.
-     * This property limits maximum value of scale value to be allowed
+     * Configuration property to limit maximum absolute value of BigInteger scale.
+     * This property limits maximum absolute value of scale to be allowed
      * in {@link javax.json.JsonNumber#bigIntegerValue()}
      * and {@link javax.json.JsonNumber#bigIntegerValueExact()} implemented methods.
      * Default value is set to {@code 100000}.

--- a/impl/src/main/java/org/glassfish/json/api/JsonConfig.java
+++ b/impl/src/main/java/org/glassfish/json/api/JsonConfig.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2020, 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.json.api;
+
+public interface JsonConfig {
+
+    /**
+     * Configuration property to limit maximum value of BigInteger scale value.
+     * This property limits maximum value of scale value to be allowed
+     * in {@link javax.json.JsonNumber#bigIntegerValue()}
+     * and {@link javax.json.JsonNumber#bigIntegerValueExact()} implemented methods.
+     * Default value is set to {@code 100000}.
+     */
+    String MAX_BIGINT_SCALE = "org.eclipse.parsson.maxBigIntegerScale";
+
+}

--- a/impl/src/main/java/org/glassfish/json/api/JsonConfig.java
+++ b/impl/src/main/java/org/glassfish/json/api/JsonConfig.java
@@ -34,4 +34,10 @@ public interface JsonConfig {
      */
     String MAX_BIGDECIMAL_LEN = "org.eclipse.parsson.maxBigDecimalLength";
 
+    /**
+     * Configuration property to limit maximum level of nesting when being parsing JSON string.
+     * Default value is set to {@code 1000}.
+     */
+    String MAX_DEPTH = "org.eclipse.parsson.maxDepth";
+
 }

--- a/impl/src/main/resources/org/glassfish/json/messages.properties
+++ b/impl/src/main/resources/org/glassfish/json/messages.properties
@@ -41,6 +41,7 @@ parser.state.err=Unknown value type {0}
 parser.scope.err=Cannot be called for value {0}
 parser.input.enc.detect.failed=Cannot auto-detect encoding, not enough chars
 parser.input.enc.detect.ioerr=I/O error while auto-detecting the encoding of stream
+parser.input.nested.too.deep=Input is too deeply nested {0}
 
 generator.flush.io.err=I/O error while flushing generated JSON
 generator.close.io.err=I/O error while closing JsonGenerator
@@ -54,6 +55,8 @@ generator.illegal.multiple.text=Cannot generate more than one JSON text
 writer.write.already.called=write/writeObject/writeArray/close method is already called
 
 reader.read.already.called=read/readObject/readArray/close method is already called
+
+number.scale.limit.exception=Scale value {0} of this BigInteger exceeded maximal allowed absolute value of {1}
 
 objbuilder.name.null=Name in JsonObject's name/value pair cannot be null
 objbuilder.value.null=Value in JsonObject's name/value pair cannot be null

--- a/jaxrs-1x/pom.xml
+++ b/jaxrs-1x/pom.xml
@@ -23,13 +23,13 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>json</artifactId>
-        <version>1.1.6.payara-p1</version>
+        <version>1.1.6.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>jsonp-jaxrs-1x</artifactId>
     <packaging>bundle</packaging>
-    <version>1.1.6.payara-p1</version>
+    <version>1.1.6.payara-p2-SNAPSHOT</version>
     <name>Jakarta JSON Processing Media for JAX-RS 1.1</name>
     <description>JAX-RS 1.1 MessageBodyReader and MessageBodyWriter to support JsonObject/JsonArray/JsonStructure API of Jakarta JSON Processing</description>
     <url>https://github.com/eclipse-ee4j/jsonp</url>

--- a/jaxrs-1x/pom.xml
+++ b/jaxrs-1x/pom.xml
@@ -23,13 +23,13 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>json</artifactId>
-        <version>1.1.6.payara-p1-SNAPSHOT</version>
+        <version>1.1.6.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>jsonp-jaxrs-1x</artifactId>
     <packaging>bundle</packaging>
-    <version>1.1.6.payara-p1-SNAPSHOT</version>
+    <version>1.1.6.payara-p1</version>
     <name>Jakarta JSON Processing Media for JAX-RS 1.1</name>
     <description>JAX-RS 1.1 MessageBodyReader and MessageBodyWriter to support JsonObject/JsonArray/JsonStructure API of Jakarta JSON Processing</description>
     <url>https://github.com/eclipse-ee4j/jsonp</url>

--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -23,14 +23,14 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>json</artifactId>
-        <version>1.1.6.payara-p1</version>
+        <version>1.1.6.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <groupId>org.glassfish</groupId>
     <artifactId>jsonp-jaxrs</artifactId>
     <packaging>bundle</packaging>
-    <version>1.1.6.payara-p1</version>
+    <version>1.1.6.payara-p2-SNAPSHOT</version>
     <name>Jakarta JSON Processing Media for Jakarta RESTful Web Services</name>
     <description>Jakarta RESTful Web Services MessageBodyReader and MessageBodyWriter to support JsonValue API of Jakarta JSON Processing</description>
     <url>https://github.com/eclipse-ee4j/jsonp</url>

--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -23,14 +23,14 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>json</artifactId>
-        <version>1.1.6.payara-p1-SNAPSHOT</version>
+        <version>1.1.6.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <groupId>org.glassfish</groupId>
     <artifactId>jsonp-jaxrs</artifactId>
     <packaging>bundle</packaging>
-    <version>1.1.6.payara-p1-SNAPSHOT</version>
+    <version>1.1.6.payara-p1</version>
     <name>Jakarta JSON Processing Media for Jakarta RESTful Web Services</name>
     <description>Jakarta RESTful Web Services MessageBodyReader and MessageBodyWriter to support JsonValue API of Jakarta JSON Processing</description>
     <url>https://github.com/eclipse-ee4j/jsonp</url>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <groupId>org.glassfish</groupId>
     <artifactId>json</artifactId>
     <packaging>pom</packaging>
-    <version>1.1.6.payara-p1</version>
+    <version>1.1.6.payara-p2-SNAPSHOT</version>
     <name>Jakarta JSON Processing</name>
     <description>Jakarta JSON Processing defines a Java(R) based framework for parsing, generating, transforming, and querying JSON documents.</description>
     <url>https://github.com/eclipse-ee4j/jsonp</url>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <groupId>org.glassfish</groupId>
     <artifactId>json</artifactId>
     <packaging>pom</packaging>
-    <version>1.1.6.payara-p1-SNAPSHOT</version>
+    <version>1.1.6.payara-p1</version>
     <name>Jakarta JSON Processing</name>
     <description>Jakarta JSON Processing defines a Java(R) based framework for parsing, generating, transforming, and querying JSON documents.</description>
     <url>https://github.com/eclipse-ee4j/jsonp</url>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>json</artifactId>
-        <version>1.1.6.payara-p1-SNAPSHOT</version>
+        <version>1.1.6.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>json</artifactId>
-        <version>1.1.6.payara-p1</version>
+        <version>1.1.6.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/src/test/java/org/glassfish/json/TestUtils.java
+++ b/tests/src/test/java/org/glassfish/json/TestUtils.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.json;
+
+import java.io.StringReader;
+import javax.json.JsonReader;
+import javax.json.JsonValue;
+
+import java.util.Collections;
+
+/**
+ * Local test utils.
+ */
+public class TestUtils {
+
+    /**
+     * Creates an instance of JSON Merge Patch with empty context.
+     *
+     * @param patch JSON Merge Patch
+     * @return new JSON Merge Patch instance
+     */
+    public static JsonMergePatchImpl createJsonMergePatchImpl(JsonValue patch) {
+        return new JsonMergePatchImpl(patch, new JsonContext(null, new BufferPoolImpl()));
+    }
+
+    /**
+     * Reads the input JSON text and returns a JsonValue.
+     * <p>For convenience, single quotes as well as double quotes
+     * are allowed to delimit JSON strings. If single quotes are
+     * used, any quotes, single or double, in the JSON string must be
+     * escaped (prepend with a '\').
+     *
+     * @param jsonString the input JSON data
+     * @return the object model for {@code jsonString}
+     * @throws javax.json.stream.JsonParsingException if the input is not legal JSON text
+     */
+    public static JsonValue toJson(String jsonString) {
+        StringBuilder builder = new StringBuilder();
+        boolean single_context = false;
+        for (int i = 0; i < jsonString.length(); i++) {
+            char ch = jsonString.charAt(i);
+            if (ch == '\\') {
+                i = i + 1;
+                if (i < jsonString.length()) {
+                    ch = jsonString.charAt(i);
+                    if (!(single_context && ch == '\'')) {
+                        // unescape ' inside single quotes
+                        builder.append('\\');
+                    }
+                }
+            } else if (ch == '\'') {
+                // Turn ' into ", for proper JSON string
+                ch = '"';
+                single_context = ! single_context;
+            }
+            builder.append(ch);
+        }
+
+        JsonReader reader = new JsonReaderImpl(
+                new StringReader(builder.toString()),
+                new JsonContext(Collections.emptyMap(), new BufferPoolImpl()));
+        JsonValue value = reader.readValue();
+        reader.close();
+        return value;
+    }
+
+
+}

--- a/tests/src/test/java/org/glassfish/json/tests/JsonBigDecimalLengthLimitTest.java
+++ b/tests/src/test/java/org/glassfish/json/tests/JsonBigDecimalLengthLimitTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.json.tests;
+
+import java.io.StringReader;
+import java.math.BigDecimal;
+
+import javax.json.Json;
+import javax.json.JsonNumber;
+import javax.json.JsonReader;
+import javax.json.JsonValue;
+import junit.framework.TestCase;
+import org.glassfish.json.api.JsonConfig;
+
+/**
+ * Test maxBigDecimalLength limit set from System property.
+ */
+public class JsonBigDecimalLengthLimitTest extends TestCase  {
+
+    public JsonBigDecimalLengthLimitTest(String testName) {
+        super(testName);
+    }
+
+    @Override
+    protected void setUp() {
+        System.setProperty(JsonConfig.MAX_BIGDECIMAL_LEN, "500");
+    }
+
+    @Override
+    protected void tearDown() {
+        System.clearProperty(JsonConfig.MAX_BIGDECIMAL_LEN);
+    }
+
+    // Test BigDecimal max source characters array length using length equal to system property limit of 500.
+    // Parsing shall pass and return value equal to source String.
+    public void testLargeBigDecimalBellowLimit() {
+        JsonReader reader = Json.createReader(new StringReader(JsonNumberTest.Π_500));
+        JsonNumber check = Json.createValue(new BigDecimal(JsonNumberTest.Π_500));
+        JsonValue value = reader.readValue();
+        assertEquals(value.getValueType(), JsonValue.ValueType.NUMBER);
+        assertEquals(value, check);
+    }
+
+    // Test BigDecimal max source characters array length using length above system property limit of 500.
+    // Parsing shall pass and return value equal to source String.
+    public void testLargeBigDecimalAboveLimit() {
+        JsonReader reader = Json.createReader(new StringReader(JsonNumberTest.Π_501));
+        try {
+            reader.readValue();
+            fail("No exception was thrown from BigDecimal parsing with source characters array length over limit");
+        } catch (UnsupportedOperationException e) {
+            // UnsupportedOperationException is expected to be thrown
+            assertEquals(
+                    "Number of BigDecimal source characters 501 exceeded maximal allowed value of 500",
+                    e.getMessage());
+        }
+    }
+
+}

--- a/tests/src/test/java/org/glassfish/json/tests/JsonBigDecimalScaleLimitTest.java
+++ b/tests/src/test/java/org/glassfish/json/tests/JsonBigDecimalScaleLimitTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.json.tests;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+import javax.json.Json;
+import junit.framework.TestCase;
+
+/**
+ * Test maxBigIntegerScale limit set from System property.
+ */
+public class JsonBigDecimalScaleLimitTest extends TestCase {
+
+    public JsonBigDecimalScaleLimitTest(String testName) {
+        super(testName);
+    }
+
+    @Override
+    protected void setUp() {
+        System.setProperty("org.eclipse.parsson.maxBigIntegerScale", "50000");
+    }
+
+    @Override
+    protected void tearDown() {
+        System.clearProperty("org.eclipse.parsson.maxBigIntegerScale");
+    }
+
+    // Test BigInteger scale value limit set from system property using value bellow limit.
+    // Call shall return value.
+    public void testSystemPropertyBigIntegerScaleBellowLimit() {
+        BigDecimal value = new BigDecimal("3.1415926535897932384626433");
+        Json.createValue(value).bigIntegerValue();
+    }
+
+    // Test BigInteger scale value limit set from system property using value above limit.
+    // Call shall throw specific UnsupportedOperationException exception.
+    // Default value is 100000 and system property lowered it to 50000 so value with scale 50001
+    // test shall fail with exception message matching modified limits.
+    public void testSystemPropertyBigIntegerScaleAboveLimit() {
+        BigDecimal value = new BigDecimal("3.1415926535897932384626433")
+                .setScale(50001, RoundingMode.HALF_UP);
+        try {
+            Json.createValue(value).bigIntegerValue();
+            fail("No exception was thrown from bigIntegerValue with scale over limit");
+        } catch (UnsupportedOperationException e) {
+            // UnsupportedOperationException is expected to be thrown
+            assertEquals(
+                    "Scale value 50001 of this BigInteger exceeded maximal allowed value of 50000",
+                    e.getMessage());
+        }
+        System.clearProperty("org.eclipse.parsson.maxBigIntegerScale");
+    }
+
+}

--- a/tests/src/test/java/org/glassfish/json/tests/JsonBigDecimalScaleLimitTest.java
+++ b/tests/src/test/java/org/glassfish/json/tests/JsonBigDecimalScaleLimitTest.java
@@ -28,13 +28,15 @@ import org.glassfish.json.api.JsonConfig;
  */
 public class JsonBigDecimalScaleLimitTest extends TestCase {
 
+    private static final int MAX_BIGINTEGER_SCALE = 50000;
+
     public JsonBigDecimalScaleLimitTest(String testName) {
         super(testName);
     }
 
     @Override
     protected void setUp() {
-        System.setProperty(JsonConfig.MAX_BIGINTEGER_SCALE, "50000");
+        System.setProperty(JsonConfig.MAX_BIGINTEGER_SCALE, Integer.toString(MAX_BIGINTEGER_SCALE));
     }
 
     @Override
@@ -61,9 +63,26 @@ public class JsonBigDecimalScaleLimitTest extends TestCase {
             fail("No exception was thrown from bigIntegerValue with scale over limit");
         } catch (UnsupportedOperationException e) {
             // UnsupportedOperationException is expected to be thrown
-            assertEquals(
-                    "Scale value 50001 of this BigInteger exceeded maximal allowed value of 50000",
-                    e.getMessage());
+            JsonNumberTest.assertExceptionMessageContainsNumber(e, 50001);
+            JsonNumberTest.assertExceptionMessageContainsNumber(e, MAX_BIGINTEGER_SCALE);
+        }
+        System.clearProperty("org.eclipse.parsson.maxBigIntegerScale");
+    }
+
+    // Test BigInteger scale value limit set from system property using value above limit.
+    // Call shall throw specific UnsupportedOperationException exception.
+    // Default value is 100000 and system property lowered it to 50000 so value with scale -50001
+    // test shall fail with exception message matching modified limits.
+    public void testSystemPropertyBigIntegerNegScaleAboveLimit() {
+        BigDecimal value = new BigDecimal("3.1415926535897932384626433")
+                .setScale(-50001, RoundingMode.HALF_UP);
+        try {
+            Json.createValue(value).bigIntegerValue();
+            fail("No exception was thrown from bigIntegerValue with scale over limit");
+        } catch (UnsupportedOperationException e) {
+            // UnsupportedOperationException is expected to be thrown
+            JsonNumberTest.assertExceptionMessageContainsNumber(e, -50001);
+            JsonNumberTest.assertExceptionMessageContainsNumber(e, MAX_BIGINTEGER_SCALE);
         }
         System.clearProperty("org.eclipse.parsson.maxBigIntegerScale");
     }

--- a/tests/src/test/java/org/glassfish/json/tests/JsonBigDecimalScaleLimitTest.java
+++ b/tests/src/test/java/org/glassfish/json/tests/JsonBigDecimalScaleLimitTest.java
@@ -21,6 +21,7 @@ import java.math.RoundingMode;
 
 import javax.json.Json;
 import junit.framework.TestCase;
+import org.glassfish.json.api.JsonConfig;
 
 /**
  * Test maxBigIntegerScale limit set from System property.
@@ -33,12 +34,12 @@ public class JsonBigDecimalScaleLimitTest extends TestCase {
 
     @Override
     protected void setUp() {
-        System.setProperty("org.eclipse.parsson.maxBigIntegerScale", "50000");
+        System.setProperty(JsonConfig.MAX_BIGINTEGER_SCALE, "50000");
     }
 
     @Override
     protected void tearDown() {
-        System.clearProperty("org.eclipse.parsson.maxBigIntegerScale");
+        System.clearProperty(JsonConfig.MAX_BIGINTEGER_SCALE);
     }
 
     // Test BigInteger scale value limit set from system property using value bellow limit.

--- a/tests/src/test/java/org/glassfish/json/tests/JsonCollectorTest.java
+++ b/tests/src/test/java/org/glassfish/json/tests/JsonCollectorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -25,7 +25,7 @@ import javax.json.JsonObject;
 import javax.json.JsonPatchBuilder;
 import javax.json.JsonValue;
 import javax.json.stream.JsonCollectors;
-import org.glassfish.json.JsonUtil;
+import org.glassfish.json.TestUtils;
 
 import static org.junit.Assert.assertEquals;
 
@@ -40,7 +40,7 @@ public class JsonCollectorTest {
     @BeforeClass
     public static void setUpClass() {
         // The JSON source
-        contacts = (JsonArray) JsonUtil.toJson(
+        contacts = (JsonArray) TestUtils.toJson(
         "[                                 " +
         "  { 'name': 'Duke',               " +
         "    'age': 18,                    " +
@@ -70,7 +70,7 @@ public class JsonCollectorTest {
                    .filter(x->"F".equals(x.getString("gender")))
                    .map(x-> x.get("name"))
                    .collect(JsonCollectors.toJsonArray());
-        JsonValue expected = JsonUtil.toJson("['Jane','Joanna']");
+        JsonValue expected = TestUtils.toJson("['Jane','Joanna']");
         assertEquals(expected, result);
     }
 
@@ -86,7 +86,7 @@ public class JsonCollectorTest {
                             x->x.asJsonObject().getString("name"),
                             x->x.asJsonObject().getJsonObject("phones").get("mobile")))
                     ;
-        JsonValue expected = JsonUtil.toJson(
+        JsonValue expected = TestUtils.toJson(
                 "{'Jane': '707-999-5555', 'Joanna': '505-333-4444'}");
         assertEquals(expected, result);
     }
@@ -99,7 +99,7 @@ public class JsonCollectorTest {
          */
         JsonObject result = contacts.getValuesAs(JsonObject.class).stream()
             .collect(JsonCollectors.groupingBy(x->((JsonObject)x).getString("gender")));
-        JsonValue expected = JsonUtil.toJson(
+        JsonValue expected = TestUtils.toJson(
         "{'F':                               " +
         "  [                                 " +
         "    { 'name': 'Jane',               " +
@@ -141,7 +141,7 @@ public class JsonCollectorTest {
             .forEach(p-> builder.replace("/"+index+"/age", p.getInt("age")+1));
         JsonArray result = builder.build().apply(contacts);
 
-        JsonValue expected = (JsonArray) JsonUtil.toJson(
+        JsonValue expected = (JsonArray) TestUtils.toJson(
         "[                                 " +
         "  { 'name': 'Duke',               " +
         "    'age': 19,                    " +

--- a/tests/src/test/java/org/glassfish/json/tests/JsonMergePatch2Test.java
+++ b/tests/src/test/java/org/glassfish/json/tests/JsonMergePatch2Test.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.json.tests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.glassfish.json.TestUtils;
+import org.junit.Test;
+
+import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonMergePatch;
+import javax.json.JsonPatch;
+
+public class JsonMergePatch2Test {
+
+    @Test
+    public void testToString() {
+        JsonArray jsonArray = Json.createArrayBuilder().add(Json.createValue(1)).build();
+        JsonPatch jsonPatch = Json.createPatchBuilder(jsonArray).build();
+        assertEquals("[1]", jsonPatch.toString());
+        JsonMergePatch jsonMergePatch = Json.createMergePatch(jsonArray);
+        assertEquals("[1]", jsonMergePatch.toString());
+    }
+
+    @Test
+    public void testEquals() {
+        JsonMergePatch j1 = TestUtils.createJsonMergePatchImpl(Json.createValue("test"));
+        JsonMergePatch j2 = TestUtils.createJsonMergePatchImpl(Json.createValue("test"));
+        JsonMergePatch j3 = TestUtils.createJsonMergePatchImpl(j1.toJsonValue());
+        JsonMergePatch j4 = TestUtils.createJsonMergePatchImpl(Json.createValue("test2"));
+        JsonMergePatch j5 = TestUtils.createJsonMergePatchImpl(null);
+
+        assertTrue(j1.equals(j1));
+
+        assertTrue(j1.equals(j2));
+        assertTrue(j2.equals(j1));
+
+        assertTrue(j1.equals(j3));
+        assertTrue(j3.equals(j1));
+
+        assertTrue(j2.equals(j3));
+        assertTrue(j3.equals(j2));
+
+        assertFalse(j1.equals(j4));
+        assertFalse(j1.equals(j5));
+        assertFalse(j1.equals(null));
+    }
+
+}

--- a/tests/src/test/java/org/glassfish/json/tests/JsonNestingTest.java
+++ b/tests/src/test/java/org/glassfish/json/tests/JsonNestingTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.glassfish.json.tests;
+
+import javax.json.Json;
+import javax.json.stream.JsonParser;
+import org.junit.Test;
+
+import java.io.StringReader;
+
+public class JsonNestingTest {
+
+    @Test(expected = RuntimeException.class)
+    public void testArrayNestingException() {
+        String json = createDeepNestedDoc(500);
+        try (JsonParser parser = Json.createParser(new StringReader(json))) {
+            while (parser.hasNext()) {
+                JsonParser.Event ev = parser.next();
+                if (JsonParser.Event.START_ARRAY == ev) {
+                    parser.getArray();
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testArrayNesting() {
+        String json = createDeepNestedDoc(499);
+        try (JsonParser parser = Json.createParser(new StringReader(json))) {
+            while (parser.hasNext()) {
+                JsonParser.Event ev = parser.next();
+                if (JsonParser.Event.START_ARRAY == ev) {
+                    parser.getArray();
+                }
+            }
+        }
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testObjectNestingException() {
+        String json = createDeepNestedDoc(500);
+        try (JsonParser parser = Json.createParser(new StringReader(json))) {
+            while (parser.hasNext()) {
+                JsonParser.Event ev = parser.next();
+                if (JsonParser.Event.START_OBJECT == ev) {
+                    parser.getObject();
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testObjectNesting() {
+        String json = createDeepNestedDoc(499);
+        try (JsonParser parser = Json.createParser(new StringReader(json))) {
+            while (parser.hasNext()) {
+                JsonParser.Event ev = parser.next();
+                if (JsonParser.Event.START_OBJECT == ev) {
+                    parser.getObject();
+                }
+            }
+        }
+    }
+
+    private static String createDeepNestedDoc(final int depth) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("[");
+        for (int i = 0; i < depth; i++) {
+            sb.append("{ \"a\": [");
+        }
+        sb.append(" \"val\" ");
+        for (int i = 0; i < depth; i++) {
+            sb.append("]}");
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+
+}

--- a/tests/src/test/java/org/glassfish/json/tests/JsonNumberTest.java
+++ b/tests/src/test/java/org/glassfish/json/tests/JsonNumberTest.java
@@ -25,6 +25,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
 import java.util.HashMap;
+import java.text.MessageFormat;
 import java.util.Map;
 
 import org.glassfish.json.api.JsonConfig;
@@ -56,6 +57,9 @@ public class JsonNumberTest extends TestCase {
 
     // π as JsonNumber with 1101 source characters
     private static final String Π_1101 = Π_1100 + "5";
+
+    // Default maximum value of BigInteger scale value limit from JsonContext
+    private static final int DEFAULT_MAX_BIGINTEGER_SCALE = 100000;
 
     public JsonNumberTest(String testName) {
         super(testName);
@@ -242,7 +246,7 @@ public class JsonNumberTest extends TestCase {
         Json.createValue(value).bigIntegerValue();
     }
 
-    // Test default BigInteger scale value limit using value above limit.
+    // Test default BigInteger scale value limit using positive value above limit.
     // Call shall throw specific UnsupportedOperationException exception.
     public void testDefaultBigIntegerScaleAboveLimit() {
         BigDecimal value = new BigDecimal("3.1415926535897932384626433")
@@ -252,9 +256,23 @@ public class JsonNumberTest extends TestCase {
             fail("No exception was thrown from bigIntegerValue with scale over limit");
         } catch (UnsupportedOperationException e) {
             // UnsupportedOperationException is expected to be thrown
-            assertEquals(
-                    "Scale value 100001 of this BigInteger exceeded maximal allowed value of 100000",
-                    e.getMessage());
+            assertExceptionMessageContainsNumber(e, 100001);
+            assertExceptionMessageContainsNumber(e, DEFAULT_MAX_BIGINTEGER_SCALE);
+        }
+    }
+
+    // Test default BigInteger scale value limit using negative value above limit.
+    // Call shall throw specific UnsupportedOperationException exception.
+    public void testDefaultBigIntegerNegScaleAboveLimit() {
+        BigDecimal value = new BigDecimal("3.1415926535897932384626433")
+                .setScale(-100001, RoundingMode.HALF_UP);
+        try {
+            Json.createValue(value).bigIntegerValue();
+            fail("No exception was thrown from bigIntegerValue with scale over limit");
+        } catch (UnsupportedOperationException e) {
+            // UnsupportedOperationException is expected to be thrown
+            assertExceptionMessageContainsNumber(e, -100001);
+            assertExceptionMessageContainsNumber(e, DEFAULT_MAX_BIGINTEGER_SCALE);
         }
     }
 
@@ -277,9 +295,32 @@ public class JsonNumberTest extends TestCase {
             fail("No exception was thrown from bigIntegerValue with scale over limit");
         } catch (UnsupportedOperationException e) {
             // UnsupportedOperationException is expected to be thrown
-            assertEquals(
-                    "Scale value 50001 of this BigInteger exceeded maximal allowed value of 50000",
-                    e.getMessage());
+            assertExceptionMessageContainsNumber(e, 50001);
+            assertExceptionMessageContainsNumber(e, 50000);
+        }
+    }
+
+    // Test BigInteger scale value limit set from config Map using value above limit.
+    // Call shall throw specific UnsupportedOperationException exception.
+    // Config Map limit is stored in target JsonObject and shall be present for later value manipulation.
+    // Default value is 100000 and config Map property lowered it to 50000 so value with scale -50001
+    // test shall fail with exception message matching modified limits.
+    public void testConfigBigIntegerNegScaleAboveLimit() {
+        BigDecimal value = new BigDecimal("3.1415926535897932384626433")
+                .setScale(-50001, RoundingMode.HALF_UP);
+        Map<String, String> config = new HashMap<>();
+        config.put(JsonConfig.MAX_BIGINTEGER_SCALE, "50000");
+        try {
+            JsonObject jsonObject = Json.createBuilderFactory(config)
+                    .createObjectBuilder()
+                    .add("bigDecimal", value)
+                    .build();
+            jsonObject.getJsonNumber("bigDecimal").bigIntegerValue();
+            fail("No exception was thrown from bigIntegerValue with scale over limit");
+        } catch (UnsupportedOperationException e) {
+            // UnsupportedOperationException is expected to be thrown
+            assertExceptionMessageContainsNumber(e, -50001);
+            assertExceptionMessageContainsNumber(e, 50000);
         }
     }
 
@@ -338,4 +379,12 @@ public class JsonNumberTest extends TestCase {
                     e.getMessage());
         }
     }
+
+    static void assertExceptionMessageContainsNumber(Exception e, int number) {
+        // Format the number as being written to message from messages bundle
+        String numberString = MessageFormat.format("{0}", number);
+        assertTrue("Substring \"" + numberString + "\" was not found in \"" + e.getMessage() + "\"",
+                   e.getMessage().contains(numberString));
+    }
+
 }

--- a/tests/src/test/java/org/glassfish/json/tests/JsonNumberTest.java
+++ b/tests/src/test/java/org/glassfish/json/tests/JsonNumberTest.java
@@ -27,10 +27,36 @@ import java.math.RoundingMode;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.glassfish.json.api.JsonConfig;
+
 /**
  * @author Jitendra Kotamraju
  */
 public class JsonNumberTest extends TestCase {
+
+    // π as JsonNumber with 500 source characters
+    static final String Π_500
+            = "3.14159265358979323846264338327950288419716939937510582097494459230781640628620899862803482534211706"
+            + "7982148086513282306647093844609550582231725359408128481117450284102701938521105559644622948954930381"
+            + "9644288109756659334461284756482337867831652712019091456485669234603486104543266482133936072602491412"
+            + "7372458700660631558817488152092096282925409171536436789259036001133053054882046652138414695194151160"
+            + "9433057270365759591953092186117381932611793105118548074462379962749567351885752724891227938183011949";
+
+    // π as JsonNumber with 501 source characters
+    static final String Π_501 = Π_500 + "1";
+
+    // π as JsonNumber with 1100 source characters
+    private static final String Π_1100 = Π_500
+            + "1298336733624406566430860213949463952247371907021798609437027705392171762931767523846748184676694051"
+            + "3200056812714526356082778577134275778960917363717872146844090122495343014654958537105079227968925892"
+            + "3542019956112129021960864034418159813629774771309960518707211349999998372978049951059731732816096318"
+            + "5950244594553469083026425223082533446850352619311881710100031378387528865875332083814206171776691473"
+            + "0359825349042875546873115956286388235378759375195778185778053217122680661300192787661119590921642019"
+            + "8938095257201065485863278865936153381827968230301952035301852968995773622599413891249721775283479131";
+
+    // π as JsonNumber with 1101 source characters
+    private static final String Π_1101 = Π_1100 + "5";
+
     public JsonNumberTest(String testName) {
         super(testName);
     }
@@ -242,7 +268,6 @@ public class JsonNumberTest extends TestCase {
                 .setScale(50001, RoundingMode.HALF_UP);
         Map<String, String> config = new HashMap<>();
         config.put("org.eclipse.parsson.maxBigIntegerScale", "50000");
-
         try {
             JsonObject jsonObject = Json.createBuilderFactory(config)
                     .createObjectBuilder()
@@ -254,6 +279,62 @@ public class JsonNumberTest extends TestCase {
             // UnsupportedOperationException is expected to be thrown
             assertEquals(
                     "Scale value 50001 of this BigInteger exceeded maximal allowed value of 50000",
+                    e.getMessage());
+        }
+    }
+
+    // Test BigDecimal max source characters array length using length equal to default limit of 1100.
+    // Parsing shall pass and return value equal to source String.
+    public void testLargeBigDecimalBellowLimit() {
+        JsonReader reader = Json.createReader(new StringReader(Π_1100));
+        JsonNumber check = Json.createValue(new BigDecimal(Π_1100));
+        JsonValue value = reader.readValue();
+        assertEquals(value.getValueType(), JsonValue.ValueType.NUMBER);
+        assertEquals(value, check);
+    }
+
+    // Test BigDecimal max source characters array length using length above default limit of 1100.
+    // Parsing shall throw specific UnsupportedOperationException exception.
+    public void testLargeBigDecimalAboveLimit() {
+        JsonReader reader = Json.createReader(new StringReader(Π_1101));
+        try {
+            reader.readValue();
+            fail("No exception was thrown from BigDecimal parsing with source characters array length over limit");
+        } catch (UnsupportedOperationException e) {
+            // UnsupportedOperationException is expected to be thrown
+            assertEquals(
+                    "Number of BigDecimal source characters 1101 exceeded maximal allowed value of 1100",
+                    e.getMessage());
+        }
+    }
+
+    // Test BigDecimal max source characters array length using length equal to custom limit of 500.
+    // Parsing shall pass and return value equal to source String.
+    public void testLargeBigDecimalBellowCustomLimit() {
+        Map<String, String> config = new HashMap<>();
+        config.put(JsonConfig.MAX_BIGDECIMAL_LEN, "500");
+
+        JsonReader reader = Json.createReaderFactory(config).createReader(new StringReader(Π_500));
+        JsonNumber check = Json.createValue(new BigDecimal(Π_500));
+        JsonValue value = reader.readValue();
+        assertEquals(value.getValueType(), JsonValue.ValueType.NUMBER);
+        assertEquals(value, check);
+    }
+
+    // Test BigDecimal max source characters array length using length equal to custom limit of 200.
+    // Parsing shall pass and return value equal to source String.
+    public void testLargeBigDecimalAboveCustomLimit() {
+        Map<String, String> config = new HashMap<>();
+        config.put(JsonConfig.MAX_BIGDECIMAL_LEN, "500");
+
+        JsonReader reader = Json.createReaderFactory(config).createReader(new StringReader(Π_501));
+        try {
+            reader.readValue();
+            fail("No exception was thrown from BigDecimal parsing with source characters array length over limit");
+        } catch (UnsupportedOperationException e) {
+            // UnsupportedOperationException is expected to be thrown
+            assertEquals(
+                    "Number of BigDecimal source characters 501 exceeded maximal allowed value of 500",
                     e.getMessage());
         }
     }

--- a/tests/src/test/java/org/glassfish/json/tests/ToJsonTest.java
+++ b/tests/src/test/java/org/glassfish/json/tests/ToJsonTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,7 +23,7 @@ import javax.json.JsonArray;
 import javax.json.JsonArrayBuilder;
 import javax.json.JsonValue;
 
-import org.glassfish.json.JsonUtil;
+import org.glassfish.json.TestUtils;
 
 import static org.junit.Assert.assertEquals;
 /**
@@ -33,9 +33,9 @@ public class ToJsonTest {
 
     @Test
     public void testToJson() {
-        assertEquals(Json.createValue("someString"), JsonUtil.toJson("'someString'"));
-        assertEquals(Json.createValue("some'thing"), JsonUtil.toJson("'some\\'thing'"));
-        assertEquals(Json.createValue("some\"thing"), JsonUtil.toJson("'some\\\"thing'"));
+        assertEquals(Json.createValue("someString"), TestUtils.toJson("'someString'"));
+        assertEquals(Json.createValue("some'thing"), TestUtils.toJson("'some\\'thing'"));
+        assertEquals(Json.createValue("some\"thing"), TestUtils.toJson("'some\\\"thing'"));
         JsonArrayBuilder builder = Json.createArrayBuilder();
         JsonArray array = builder
             .add(Json.createObjectBuilder()
@@ -49,7 +49,7 @@ public class ToJsonTest {
                 .add("educations", Json.createArrayBuilder()
                     .add("Oxford")))
             .build();
-         JsonValue expected = JsonUtil.toJson(
+         JsonValue expected = TestUtils.toJson(
              "[ { 'name': 'John', " +
                  "'age': 35, " +
                  "'educations': ['Gunn High', 'UC Berkeley'] }, " +


### PR DESCRIPTION
Backports fixes from Parsson to address the titular CVE.

The EE8 version of JSONP-Impl / Parsson is unsupported - Parsson don't even have a branch for it.
This means I've had to make some adjustments to the PRs, as they were built on top of all the other changes which have happened between EE8 and now (e.g. introducing functionality for rejecting duplicate keys).
I've tried to remove these where I can, but the first PR mixed in a big rework away from using a `BufferPool` class which I deemed too entwined to spend time unpicking.

As an aside, I elected to leave the new Parsson property names as they are rather than converting them to `org.glassfish.json.*` - I don't think it's worth changing them; if we elect to try maintaining an EE 8 version of Parsson in the upstream Eclipse repo they'll likely want to keep the Parsson namespace.

I've ran the unit tests and loaded the admin console in Payara as my local tests, I'm deploying a snapshot to let Jenkins do a run of the JSONP TCK and our usual battery of suites.
Links pending...